### PR TITLE
bindgen: write header even when no_includes==true

### DIFF
--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -158,6 +158,7 @@ impl Bindings {
         if !self.config.no_includes
             || !self.config.includes.is_empty()
             || !self.config.sys_includes.is_empty()
+            || !self.config.header.is_none()
         {
             self.write_headers(&mut out);
         }


### PR DESCRIPTION
Currently (release 0.8.2), if `config.header` is set to `Some(x)` and `config.no_includes` is set to `true`, the header is not written. I think this is a bug and this patch fixes that.