### PR TITLE
Update libc to 0.2.144

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "lock_api"


### PR DESCRIPTION
Update libc to 0.2.144 to resolve compile errors for LoongArch target:

```
error[E0412]: cannot find type `__u64` in the crate root
 --> /home/hev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.121/src/unix/linux_like/linux/non_exhaustive.rs:5:22
  |
5 |         pub flags: ::__u64,
  |                      ^^^^^ not found in the crate root

error[E0412]: cannot find type `__u64` in the crate root
 --> /home/hev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.121/src/unix/linux_like/linux/non_exhaustive.rs:6:21
  |
6 |         pub mode: ::__u64,
  |                     ^^^^^ not found in the crate root

error[E0412]: cannot find type `__u64` in the crate root
 --> /home/hev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.121/src/unix/linux_like/linux/non_exhaustive.rs:7:24
  |
7 |         pub resolve: ::__u64,
  |                        ^^^^^ not found in the crate root
```