### PR TITLE
Look for config files next to input files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,11 @@ fn load_bindings(input: &Path, matches: &ArgMatches) -> Result<Bindings, Error> 
         // Load any config specified or search in the input directory
         let mut config = match matches.value_of("config") {
             Some(c) => Config::from_file(c).unwrap(),
-            None => Config::from_root_or_default(input),
+            None => Config::from_root_or_default(
+                input
+                    .parent()
+                    .expect("All files should have a parent directory"),
+            ),
         };
 
         apply_config_overrides(&mut config, matches);


### PR DESCRIPTION
Previously config files next to an explicit input file could not be picked up, since the `from_root_or_default` functions assumes the input path is a directory.
This is the case for all other usages of the function, but in this case we know the input is a file, so we should determine the parent directory and look for the config file in that directory. There can't be a folder with the same name as the input file, so it's not possible that we won't pick up any files anymore that we previously did.