### PR TITLE
 CI: Restore release action and add semver checks to CI deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       # someone with permissions to create a tag.
       contents: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3
@@ -25,9 +25,9 @@ jobs:
         toolchain: stable
 
     - name: semver
-      uses: obi1kenobi/cargo-semver-checks-action@v2
-      with:
-        rust-toolchain: stable
+      run: |
+        cargo install cargo-semver-checks --locked
+        cargo semver-checks check-release
 
     - name: Build cbindgen
       run: |
@@ -51,11 +51,8 @@ jobs:
         sed '$ d' | awk '{$1=$1};1' > CHANGES.txt
 
     - name: Create a release
-      uses: softprops/action-gh-release@v1
-      with:
-        name: v${{ steps.tagName.outputs.version }}
-        body_path: CHANGES.txt
-        files: |
-          target/release/cbindgen
+      run: |
+        TAG=${{ steps.tagName.outputs.version }}
+        gh release create ${TAG} --title "${TAG}" --notes-file "CHANGES.txt" --draft 'target/release/cbindgen#cbindgen-ubuntu20.04'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ on:
 jobs:
 
   linux-binaries:
+    permissions:
+      # Grant the GITHUB_TOKEN additional permissions necessary for creating a release.
+      # We only run this action for tags, so any code has already been reviewed by
+      # someone with permissions to create a tag.
+      contents: write
 
     runs-on: ubuntu-latest
 
@@ -18,6 +23,11 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+
+    - name: semver
+      uses: obi1kenobi/cargo-semver-checks-action@v2
+      with:
+        rust-toolchain: stable
 
     - name: Build cbindgen
       run: |

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+## 0.25.0
+
+      * Re-release of yanked 0.24.6 as a major release
+      * Update MSRV to 1.57
+      * Support variadic arguments (`...`) (#805)
+      * Add --depfile option (#820)
+      * Breaking changes: The `Config` struct now has a private member.
+
 ## 0.24.6 (YANKED: depfile option was breaking, see #841)
 
       * Update MSRV to 1.57


### PR DESCRIPTION
This MR restores the release action, which creates a github release upon tag.
We now use the github-cli to release the release instead of the third party action, which is not allowed by mozilla.
