### PR TITLE
Fix swapping of `>>=` and `<<=` in constants

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+# Unreleased
+
+      * Fix swapping of `>>=` and `<<=` in constants.
+
 ## 0.24.6 (YANKED: depfile option was breaking, see #841)
 
       * Update MSRV to 1.57

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -321,8 +321,8 @@ impl Literal {
                     syn::BinOp::BitXorEq(..) => "^=",
                     syn::BinOp::BitAndEq(..) => "&=",
                     syn::BinOp::BitOrEq(..) => "|=",
-                    syn::BinOp::ShlEq(..) => ">>=",
-                    syn::BinOp::ShrEq(..) => "<<=",
+                    syn::BinOp::ShlEq(..) => "<<=",
+                    syn::BinOp::ShrEq(..) => ">>=",
                 };
                 Ok(Literal::BinOp {
                     left: Box::new(l),


### PR DESCRIPTION
`ShlEq` is shift left equals, i.e. `<<=`, so it was previously mapped the wrong way.