### PR TITLE
Generate bindings for non-public extern items

### DIFF
--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -26,7 +26,11 @@ pub struct Static {
 }
 
 impl Static {
-    pub fn load(item: &syn::ItemStatic, mod_cfg: Option<&Cfg>) -> Result<Static, String> {
+    pub fn load(
+        path: Path,
+        item: &syn::ItemStatic,
+        mod_cfg: Option<&Cfg>,
+    ) -> Result<Static, String> {
         let ty = Type::load(&item.ty)?;
 
         if ty.is_none() {
@@ -34,7 +38,7 @@ impl Static {
         }
 
         Ok(Static::new(
-            Path::new(item.ident.unraw().to_string()),
+            path,
             ty.unwrap(),
             item.mutability.is_some(),
             Cfg::append(mod_cfg, Cfg::load(&item.attrs)),

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -30,11 +30,11 @@ where
     }
 }
 
-pub trait SynItemFnHelpers: SynAttributeHelpers {
+pub trait SynItemHelpers: SynAttributeHelpers {
     fn exported_name(&self) -> Option<String>;
 }
 
-impl SynItemFnHelpers for syn::ItemFn {
+impl SynItemHelpers for syn::ItemFn {
     fn exported_name(&self) -> Option<String> {
         self.attrs
             .attr_name_value_lookup("export_name")
@@ -48,13 +48,27 @@ impl SynItemFnHelpers for syn::ItemFn {
     }
 }
 
-impl SynItemFnHelpers for syn::ImplItemMethod {
+impl SynItemHelpers for syn::ImplItemMethod {
     fn exported_name(&self) -> Option<String> {
         self.attrs
             .attr_name_value_lookup("export_name")
             .or_else(|| {
                 if self.is_no_mangle() {
                     Some(self.sig.ident.unraw().to_string())
+                } else {
+                    None
+                }
+            })
+    }
+}
+
+impl SynItemHelpers for syn::ItemStatic {
+    fn exported_name(&self) -> Option<String> {
+        self.attrs
+            .attr_name_value_lookup("export_name")
+            .or_else(|| {
+                if self.is_no_mangle() {
+                    Some(self.ident.unraw().to_string())
                 } else {
                     None
                 }

--- a/tests/expectations/non_pub_extern.c
+++ b/tests/expectations/non_pub_extern.c
@@ -1,0 +1,12 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern const uint32_t FIRST;
+
+extern const uint32_t RENAMED;
+
+void first(void);
+
+void renamed(void);

--- a/tests/expectations/non_pub_extern.compat.c
+++ b/tests/expectations/non_pub_extern.compat.c
@@ -1,0 +1,20 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+extern const uint32_t FIRST;
+
+extern const uint32_t RENAMED;
+
+void first(void);
+
+void renamed(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/non_pub_extern.cpp
+++ b/tests/expectations/non_pub_extern.cpp
@@ -1,0 +1,17 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+extern "C" {
+
+extern const uint32_t FIRST;
+
+extern const uint32_t RENAMED;
+
+void first();
+
+void renamed();
+
+} // extern "C"

--- a/tests/expectations/non_pub_extern.pyx
+++ b/tests/expectations/non_pub_extern.pyx
@@ -1,0 +1,15 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  extern const uint32_t FIRST;
+
+  extern const uint32_t RENAMED;
+
+  void first();
+
+  void renamed();

--- a/tests/rust/non_pub_extern.rs
+++ b/tests/rust/non_pub_extern.rs
@@ -1,0 +1,13 @@
+#[no_mangle]
+static FIRST: u32 = 10;
+
+#[export_name = "RENAMED"]
+static SECOND: u32 = 42;
+
+#[no_mangle]
+extern "C" fn first()
+{ }
+
+#[export_name = "renamed"]
+extern fn second()
+{ }


### PR DESCRIPTION
Generate bindings for non-public rust items. 

We shouldn't be mixing concepts of visibility and exporting. Rust dynamic libraries always export `#[no_mangle]` items regardless of their visibility. More on this can be found in the issue description

Closes #822 