### PR TITLE
Some fix for new contributers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3"
 toml = "0.5"
-proc-macro2 = "1"
+proc-macro2 = "1.0.60"
 quote = "1"
 heck = "0.4"
 

--- a/contributing.md
+++ b/contributing.md
@@ -16,6 +16,7 @@ There is continuous integration setup for `cbindgen` using [GitHub Actions](http
 
 In addition to a C/C++ compiler `cargo test` requires Python and Cython
 (`python -m pip install Cython`) for checking Cython bindings generated from tests (`.pyx` files).
+Note that the tests will be failed with Cython 3.x or later.
 
 Please run `cargo test` before filing a pull request to be sure that all tests pass. This will also update the test expectations.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
(My mother language is not English, so I may say some inappropriate things.)
I tried to contribute project, but there were some errors. I fixed them.

- This project requires nightly rust (as test uses `-Z`). Added rust-toolchain.toml.
- If proc-macro2 is older than 1.0.60, the build will fail. (cf: https://github.com/rust-lang/rust/issues/113152#issuecomment-1612580132) Changed the dependency section.
- The tests fails with Cython 3. Added some notes in contributing.md.

<details>
<summary>Cython 3 detail</summary>

As cython 3 prints this warning, the snapshot doesn't match.
```
Error compiling Cython file:
------------------------------------------------------------
...
from libc.stdint cimport int8_t, int16_t,

int32_t, int64_t, intptr_t
^
------------------------------------------------------------

tests/expectations/workspace.tag.pyx:1:0: Dotted filenames ('workspace.tag.pyx') are deprecated. Please use the normal Python package directory layout.
```


</details>