### PR TITLE
Allow `=` and multiline prefix/postfix in annotations

### DIFF
--- a/src/bindgen/ir/annotation.rs
+++ b/src/bindgen/ir/annotation.rs
@@ -81,10 +81,6 @@ impl AnnotationSet {
             // Split the annotation in two
             let parts: Vec<&str> = annotation.split('=').map(|x| x.trim()).collect();
 
-            if parts.len() > 2 {
-                return Err(format!("Couldn't parse {}.", line));
-            }
-
             // Grab the name that this annotation is modifying
             let name = parts[0];
 
@@ -95,9 +91,9 @@ impl AnnotationSet {
             }
 
             // Parse the value we're setting the name to
-            let value = parts[1];
+            let value = parts[1..].join("=");
 
-            if let Some(x) = parse_list(value) {
+            if let Some(x) = parse_list(&value) {
                 annotations.insert(name.to_string(), AnnotationValue::List(x));
                 continue;
             }


### PR DESCRIPTION
This adds two things:

1. `=` is allowed in annotations. Previously, it was an error to have an `=` in the annotation but I'm doing hacky stuff (see below) and it didn't seem like there was a good reason not to permit it.
2. Multiline annotations are now supported by using a `\` at the end of the annotated line and any following lines that should be concatenated together with newlines.

What this allows is basically:

```rust
#[cfg(target_arch = "i386")]
pub mod foo {
  #[no_mangle]
  /// cbindgen:prefix= \
  /// #define FUNC_THAT_NEEDS_TO_BE_IFDEFED(x) \ \
  ///     do { \ \
  ///         do_something(x); \ \
  ///    } while (0) \
  ///
  pub extern "C" fn bar() {}
}
```

`after_include` is useful, but it has trouble when you need to conditionally compile based on the `ifdef` generated for a `cfg` attribute. This fixes that and makes it possible to somewhat hackily embed arbitrary C code wherever you want (at the cost of having to declare *something*). Eventually an annotation that can occur on a free comment might be nice to eliminate this need, but the two changes added by this PR, the `=` allowing and multiline allowing would still be needed.
