### PR TITLE
Support the "C-unwind" ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -249,7 +249,7 @@ impl SynAbiHelpers for Option<syn::Abi> {
     fn is_c(&self) -> bool {
         if let Some(ref abi) = *self {
             if let Some(ref lit_string) = abi.name {
-                return lit_string.value() == "C";
+                return matches!(lit_string.value().as_str(), "C" | "C-unwind");
             }
         }
         false
@@ -266,7 +266,7 @@ impl SynAbiHelpers for Option<syn::Abi> {
 impl SynAbiHelpers for syn::Abi {
     fn is_c(&self) -> bool {
         if let Some(ref lit_string) = self.name {
-            lit_string.value() == "C"
+            matches!(lit_string.value().as_str(), "C" | "C-unwind")
         } else {
             false
         }

--- a/tests/expectations/abi_string.c
+++ b/tests/expectations/abi_string.c
@@ -1,0 +1,8 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void c(void);
+
+void c_unwind(void);

--- a/tests/expectations/abi_string.compat.c
+++ b/tests/expectations/abi_string.compat.c
@@ -1,0 +1,16 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void c(void);
+
+void c_unwind(void);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/tests/expectations/abi_string.cpp
+++ b/tests/expectations/abi_string.cpp
@@ -1,0 +1,13 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+extern "C" {
+
+void c();
+
+void c_unwind();
+
+} // extern "C"

--- a/tests/expectations/abi_string.pyx
+++ b/tests/expectations/abi_string.pyx
@@ -1,0 +1,11 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  void c();
+
+  void c_unwind();

--- a/tests/rust/abi_string.rs
+++ b/tests/rust/abi_string.rs
@@ -1,0 +1,5 @@
+#[no_mangle]
+pub extern "C" fn c() {}
+
+#[no_mangle]
+pub extern "C-unwind" fn c_unwind() {}


### PR DESCRIPTION
The "C-unwind" ABI string has been stabilized in Rust 1.71(cf. https://github.com/rust-lang/rust/issues/74990#issuecomment-1363473645). This PR enables cbindgen to recognize these functions as C-compatible functions.

Also, I had to update the patch version of proc-macro2 in the lock file, because the nightly build failed. Maybe this should be done in Cargo.toml too?