### PR TITLE
Fix cargo semver-checks rust version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     - name: semver
       run: |
         cargo +stable install cargo-semver-checks --locked
-        cargo semver-checks check-release
+        cargo +stable semver-checks check-release
 
     - name: Build cbindgen
       run: |


### PR DESCRIPTION
I forgot forcing stable rustc for semver-checks in commit 67fea1a. On nightly Rust it is possible for the rustdoc version to be newer than what cargo semver checks supports.

This time the automatic draft release should work, I tested on my fork: https://github.com/jschwe/cbindgen/actions/runs/5978102354/job/16219504446