### PR TITLE
Bump clippy msrv to 1.64

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,2 @@
 # Specify the minimum supported Rust version
-msrv = "1.57.0"
+msrv = "1.64.0"

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -61,8 +61,10 @@ impl Language {
 /// Controls what type of line endings are used in the generated code.
 #[derive(Debug, Clone, Copy)]
 #[allow(clippy::upper_case_acronyms)]
+#[derive(Default)]
 pub enum LineEndingStyle {
     /// Use Unix-style linefeed characters
+    #[default]
     LF,
     /// Use classic Mac-style carriage-return characters
     CR,
@@ -70,12 +72,6 @@ pub enum LineEndingStyle {
     CRLF,
     /// Use the native mode for the platform: CRLF on Windows, LF everywhere else.
     Native,
-}
-
-impl Default for LineEndingStyle {
-    fn default() -> Self {
-        LineEndingStyle::LF
-    }
 }
 
 impl LineEndingStyle {
@@ -213,8 +209,9 @@ impl FromStr for DocumentationLength {
 deserialize_enum_str!(DocumentationLength);
 
 /// A style of Style to use when generating structs and enums.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum Style {
+    #[default]
     Both,
     Tag,
     Type,
@@ -242,12 +239,6 @@ impl Style {
         } else {
             "ctypedef "
         }
-    }
-}
-
-impl Default for Style {
-    fn default() -> Self {
-        Style::Both
     }
 }
 

--- a/src/bindgen/ir/repr.rs
+++ b/src/bindgen/ir/repr.rs
@@ -6,17 +6,12 @@ use syn::ext::IdentExt;
 
 use crate::bindgen::ir::ty::{IntKind, PrimitiveType};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum ReprStyle {
+    #[default]
     Rust,
     C,
     Transparent,
-}
-
-impl Default for ReprStyle {
-    fn default() -> Self {
-        ReprStyle::Rust
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/bindgen/rename.rs
+++ b/src/bindgen/rename.rs
@@ -28,9 +28,10 @@ impl<'a> IdentifierType<'a> {
 }
 
 /// A rule to apply to an identifier when generating bindings.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum RenameRule {
     /// Do not apply any renaming. The default.
+    #[default]
     None,
     /// Converts the identifier to PascalCase and adds a context dependent prefix
     GeckoCase,
@@ -90,12 +91,6 @@ impl RenameRule {
                 result
             }
         })
-    }
-}
-
-impl Default for RenameRule {
-    fn default() -> RenameRule {
-        RenameRule::None
     }
 }
 

--- a/tests/depfile.rs
+++ b/tests/depfile.rs
@@ -93,7 +93,6 @@ fn test_project(project_path: &str) {
     );
 
     std::fs::remove_dir_all(build_dir).expect("Failed to remove old build directory");
-    ()
 }
 
 macro_rules! test_file {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -251,7 +251,7 @@ fn run_compile_test(
     );
     if generate_depfile {
         let depfile = depfile_contents.expect("No depfile generated");
-        assert!(depfile.len() > 0);
+        assert!(!depfile.is_empty());
         let mut rules = depfile.split(':');
         let target = rules.next().expect("No target found");
         assert_eq!(target, generated_file.as_os_str().to_str().unwrap());


### PR DESCRIPTION
the msrv was bumped in in the Cargo.toml #847 but not in clippy.toml, clippy was complaining at startup and defaulting to 1.57