### PR TITLE
Support converting Rust `<name>: ...` to  C `...` (varargs)

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -430,6 +430,18 @@ pub struct FunctionConfig {
     pub sort_by: Option<SortKey>,
     /// Optional text to output after functions which return `!`.
     pub no_return: Option<String>,
+    /// How `va: ...` should be translated.
+    pub varargs: VarargsRule,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum VarargsRule {
+    #[default]
+    VaList,
+
+    DotDotDot,
 }
 
 impl Default for FunctionConfig {
@@ -445,6 +457,7 @@ impl Default for FunctionConfig {
             swift_name_macro: None,
             sort_by: None,
             no_return: None,
+            varargs: VarargsRule::VaList,
         }
     }
 }

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -135,6 +135,7 @@ impl<'a> Mangler<'a> {
                     self.input
                 );
             }
+            Type::VarArgs => todo!(),
         }
     }
 

--- a/tests/expectations/va_list.c
+++ b/tests/expectations/va_list.c
@@ -5,4 +5,6 @@
 
 int32_t va_list_test(va_list ap);
 
-int32_t va_list_test2(va_list ap);
+int32_t my_snprintf(char *buf, size_t n, const char *format, va_list ap);
+
+int32_t my_vsnprintf(char *buf, size_t n, const char *format, va_list ap);

--- a/tests/expectations/va_list.compat.c
+++ b/tests/expectations/va_list.compat.c
@@ -9,7 +9,9 @@ extern "C" {
 
 int32_t va_list_test(va_list ap);
 
-int32_t va_list_test2(va_list ap);
+int32_t my_snprintf(char *buf, size_t n, const char *format, va_list ap);
+
+int32_t my_vsnprintf(char *buf, size_t n, const char *format, va_list ap);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/tests/expectations/va_list.cpp
+++ b/tests/expectations/va_list.cpp
@@ -8,6 +8,8 @@ extern "C" {
 
 int32_t va_list_test(va_list ap);
 
-int32_t va_list_test2(va_list ap);
+int32_t my_snprintf(char *buf, size_t n, const char *format, va_list ap);
+
+int32_t my_vsnprintf(char *buf, size_t n, const char *format, va_list ap);
 
 } // extern "C"

--- a/tests/expectations/va_list.pyx
+++ b/tests/expectations/va_list.pyx
@@ -8,4 +8,6 @@ cdef extern from *:
 
   int32_t va_list_test(va_list ap);
 
-  int32_t va_list_test2(va_list ap);
+  int32_t my_snprintf(char *buf, size_t n, const char *format, va_list ap);
+
+  int32_t my_vsnprintf(char *buf, size_t n, const char *format, va_list ap);

--- a/tests/rust/va_list.rs
+++ b/tests/rust/va_list.rs
@@ -6,6 +6,10 @@ pub unsafe extern "C" fn va_list_test(mut ap: VaList) -> int32_t {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn va_list_test2(mut ap: ...) -> int32_t {
-    ap.arg()
+pub unsafe extern "C" fn my_snprintf(buf: *mut c_char, n: size_t, format: *const c_char, mut ap: ...) -> int32_t {
+    0
+}
+#[no_mangle]
+pub unsafe extern "C" fn my_vsnprintf(buf: *mut c_char, n: size_t, format: *const c_char, mut ap: VaList) -> int32_t {
+    0
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/cbindgen/issues/891.

I made this configurable, but I'm not sure if that's correct. Should `...` be the default, or only accepted translation, given Rust supports both `va: ...` and `va: VaList` for those two purposes?