### PR TITLE
Add docs for no-export

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -263,6 +263,23 @@ pub mod my_interesting_mod;
 pub mod my_uninteresting_mod; // This won't be scanned by cbindgen.
 ```
 
+### No export annotation
+
+cbindgen will usually emit all items it finds, as instructed by the parse and export config sections. This annotation will make cbindgen skip this item from the output, while still being aware of it. This is useful for a) suppressing "Can't find" errors and b) emitting `struct my_struct` for types in a different header (rather than a bare `my_struct`).
+
+There is no equivalent config for this annotation - by comparison, the export exclude config will cause cbindgen to not be aware of the item at all.
+
+Note that cbindgen will still traverse `no-export` structs that are `repr(C)` to emit types present in the fields. You will need to manually exclude those types in your config if desired.
+
+```
+/// cbindgen:no-export
+#[repr(C)]
+pub struct Foo { .. }; // This won't be emitted by cbindgen in the header
+
+#[repr(C)]
+fn bar() -> Foo { .. } // Will be emitted as `struct foo bar();`
+```
+
 ### Struct Annotations
 
 * field-names=\[field1, field2, ...\] -- sets the names of all the fields in the output struct. These names will be output verbatim, and are not eligible for renaming.


### PR DESCRIPTION
`no-export` is an already-existing annotation to skip emitting an item - this PR just documents it.