### PR TITLE
feat: allow users to specify a crate version for bindings generation

### DIFF
--- a/src/bindgen/cargo/cargo.rs
+++ b/src/bindgen/cargo/cargo.rs
@@ -87,7 +87,7 @@ impl Cargo {
     }
 
     pub(crate) fn binding_crate_ref(&self) -> PackageRef {
-        match self.find_pkg_ref(&self.binding_crate_name) {
+        match self.find_pkg_to_generate_bindings_ref(&self.binding_crate_name) {
             Some(pkg_ref) => pkg_ref,
             None => panic!(
                 "Unable to find {} for {:?}",
@@ -180,15 +180,28 @@ impl Cargo {
             .collect()
     }
 
-    /// Finds the package reference in `cargo metadata` that has `package_name`
-    /// ignoring the version.
-    fn find_pkg_ref(&self, package_name: &str) -> Option<PackageRef> {
+    /// Finds the package reference for which we want to generate bindings in `cargo metadata`
+    /// matching on `package_name` and verifying the manifest path matches so that we don't get a
+    /// a dependency with the same name (fix for https://github.com/mozilla/cbindgen/issues/900)
+    fn find_pkg_to_generate_bindings_ref(&self, package_name: &str) -> Option<PackageRef> {
+        // Keep a list of candidates in case the manifest check fails, so that the old behavior
+        // still applies, returning the first package that was found
+        let mut candidates = vec![];
         for package in &self.metadata.packages {
             if package.name_and_version.name == package_name {
-                return Some(package.name_and_version.clone());
+                // If we are sure it is the right package return it
+                if Path::new(package.manifest_path.as_str()) == self.manifest_path {
+                    return Some(package.name_and_version.clone());
+                }
+                // Otherwise note that a package was found
+                candidates.push(package.name_and_version.clone());
             }
         }
-        None
+
+        // If we could not verify the manifest path but we found candidates return the first one if
+        // any, this is the old behavior which did not check for manifest path, kept for backwards
+        // compatibility
+        candidates.into_iter().next()
     }
 
     /// Finds the directory for a specified package reference.


### PR DESCRIPTION
- this is useful in a setting where several crates may share the same name in e.g. a semver trick setting https://github.com/dtolnay/semver-trick to allow adding compatibility code to older versions of a crate to allow users to migrate towards newer version of a crate
- this is a pure addition and should keep all existing behaviors exactly the same

this is a PR that attemps to solve https://github.com/mozilla/cbindgen/issues/900 in a way that does not break anything that already works with cbindgen as this is a pure addition to the code base leaving all existing behaviors untouched (other solutions may involve canonicalizing paths which may panic in places where there were no panics and may cause issues for any build systems with symlinks and network disks).

This is akin to cargo's package spec e.g. `cargo build -p my_crate@0.1.0` to allow disambiguating which crate the command is referring to in cases where several crates either share the same name or several version of the same crates happen to be in the dependency/cargo metadata for a given project. The good news is that the package version is populated by Cargo in the environment when in a build system so it is easy to use for build script users. For binary users a quick parsing of their Cargo.toml with theri favorite Unix utils should be enough

To avoid changing flags a separate flag is added to the cbindgen binary and a with_crate_version is added to the cbindgen Builder to be able to use that in a build script.

@emilio as indicated in the contributing.md I am requesting a code review for this PR, I'm not quite sure how to write a test case for this right now, if you have some pointers? Maybe a separate crate_version file akin to what the profile test file might be doing ?

Cheers