### PR TITLE
Fix `..Default::default()` for struct `Config`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+# unreleased
+
+      * Revert: The `Config` struct now has a private member.
+
 # 0.26.0
 
       * Fix swapping of `>>=` and `<<=` in constants.

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -1010,8 +1010,15 @@ pub struct Config {
     pub only_target_dependencies: bool,
     /// Configuration options specific to Cython.
     pub cython: CythonConfig,
+    #[doc(hidden)]
     #[serde(skip)]
-    pub(crate) config_path: Option<StdPathBuf>,
+    /// Internal field for tracking from which file the config was loaded.
+    ///
+    /// Users should not set this field explicitly. Making the field private
+    /// prevents users from filling the struct with `..Default::default()`,
+    /// and creating a new InternalConfig struct would require more breaking
+    /// changes to our public API.
+    pub config_path: Option<StdPathBuf>,
 }
 
 impl Default for Config {


### PR DESCRIPTION
Previously the `depfile` option added a new private member to the `Config` struct - a breaking change which many users complained about. Making the field public, but hiding it from the documentation and excluding it from `serde` reverts the breakage, while keeping the depfile functionality.

I also considered adding an `InternalConfig` struct, but this would require breaking changes to at least `Config::from_file()` and `Config::from_root_or_default()`, which is a lot more invasive than my PR.

Closes #908