### PR TITLE
Add no-export in cbindgen.toml config

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -267,8 +267,6 @@ pub mod my_uninteresting_mod; // This won't be scanned by cbindgen.
 
 cbindgen will usually emit all items it finds, as instructed by the parse and export config sections. This annotation will make cbindgen skip this item from the output, while still being aware of it. This is useful for a) suppressing "Can't find" errors and b) emitting `struct my_struct` for types in a different header (rather than a bare `my_struct`).
 
-There is no equivalent config for this annotation - by comparison, the export exclude config will cause cbindgen to not be aware of the item at all.
-
 Note that cbindgen will still traverse `no-export` structs that are `repr(C)` to emit types present in the fields. You will need to manually exclude those types in your config if desired.
 
 ```
@@ -578,6 +576,10 @@ include = ["MyOrphanStruct", "MyGreatTypeRename"]
 # A list of items to not include in the generated bindings
 # default: []
 exclude = ["Bad"]
+
+# A list of items to not export in the generated bindings
+# default: []
+no_export = ["Inner"]
 
 # A prefix to add before the name of every item
 # default: no prefix is added

--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -363,6 +363,16 @@ impl Bindings {
                 continue;
             }
 
+            if self
+                .config
+                .export
+                .no_export
+                .iter()
+                .any(|i| i == item.deref().export_name())
+            {
+                continue;
+            }
+
             out.new_line_if_not_start();
             match *item {
                 ItemContainer::Constant(..) => unreachable!(),

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -180,6 +180,15 @@ impl Builder {
     }
 
     #[allow(unused)]
+    pub fn no_export_item<S: AsRef<str>>(mut self, item_name: S) -> Builder {
+        self.config
+            .export
+            .no_export
+            .push(String::from(item_name.as_ref()));
+        self
+    }
+
+    #[allow(unused)]
     pub fn rename_item<S: AsRef<str>>(mut self, from: S, to: S) -> Builder {
         self.config
             .export

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -327,6 +327,8 @@ pub struct ExportConfig {
     pub include: Vec<String>,
     /// A list of items to not include in the generated bindings
     pub exclude: Vec<String>,
+    /// A list of items to not export in the generated bindings
+    pub no_export: Vec<String>,
     /// Table of name conversions to apply to item names
     pub rename: HashMap<String, String>,
     /// Table of raw strings to prepend to the body of items.


### PR DESCRIPTION
@aidanhs @emilio 

I need it for my c binding of [OpenDAL](https://github.com/apache/opendal) and local tests pass with this change.

Let me know if this patch needs some improvement :D