### PR TITLE
Support specifying version for macro expansion.

### DIFF
--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -6,7 +6,7 @@ use std::path;
 
 use crate::bindgen::bindings::Bindings;
 use crate::bindgen::cargo::Cargo;
-use crate::bindgen::config::{Braces, Config, Language, Profile, Style};
+use crate::bindgen::config::{Braces, Config, CrateMatcher, Language, Profile, Style};
 use crate::bindgen::error::Error;
 use crate::bindgen::library::Library;
 use crate::bindgen::parser::{self, Parse};
@@ -214,8 +214,20 @@ impl Builder {
     }
 
     #[allow(unused)]
-    pub fn with_parse_expand<S: AsRef<str>>(mut self, expand: &[S]) -> Builder {
-        self.config.parse.expand.crates = expand.iter().map(|x| String::from(x.as_ref())).collect();
+    pub fn with_parse_expand<S1: AsRef<str>, S2: AsRef<str>>(
+        mut self,
+        expand: &[(S1, Option<S2>)],
+    ) -> Builder {
+        self.config.parse.expand.crates = expand
+            .iter()
+            .map(|(s1, s2)| match s2 {
+                Some(s2) => CrateMatcher::NameWithVersion {
+                    name: String::from(s1.as_ref()),
+                    version: String::from(s2.as_ref()),
+                },
+                None => CrateMatcher::Name(String::from(s1.as_ref())),
+            })
+            .collect();
         self
     }
 

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -116,7 +116,7 @@ impl<'a> Parser<'a> {
             .expand
             .crates
             .iter()
-            .any(|name| name == pkg_name)
+            .any(|name| name.matches_name(pkg_name))
         {
             return true;
         }
@@ -145,7 +145,7 @@ impl<'a> Parser<'a> {
         self.parsed_crates.insert(pkg.name.clone());
 
         // Check if we should use cargo expand for this crate
-        if self.config.parse.expand.crates.contains(&pkg.name) {
+        if self.config.parse.expand.must_expand(pkg) {
             self.parse_expand_crate(pkg)?;
         } else {
             // Parse the crate before the dependencies otherwise the same-named idents we


### PR DESCRIPTION
See: [#900].

Previously, cbindgen might sometimes match the wrong version of a crate
if the crate occurs multiple times in the dependency list produced by
`cargo metadata`. This meant that you'd observe transient errors where
_sometimes_ the right output would be produced (when the intended
version is macro-expanded), and sometimes it would not (when the wrong
version is macro-expanded).

This commit modifies the configuration to permit optionally specifying
name and version separately instead of solely specifying version.

This is an initial draft, as I have not yet been able to test it.

[#900]: https://github.com/mozilla/cbindgen/issues/900

Signed-off-by: Andrew Lilley Brinker <alilleybrinker@gmail.com>