### PR TITLE
parser: Treat omitted ABI in extern block as "C".

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -600,7 +600,7 @@ impl Parse {
         mod_cfg: Option<&Cfg>,
         item: &syn::ItemForeignMod,
     ) {
-        if !item.abi.is_c() {
+        if !item.abi.is_c() && !item.abi.is_omitted() {
             info!("Skip {} - (extern block must be extern C).", crate_name);
             return;
         }

--- a/tests/expectations/extern.c
+++ b/tests/expectations/extern.c
@@ -11,3 +11,5 @@ typedef struct {
 extern int32_t foo(void);
 
 extern void bar(Normal a);
+
+extern int32_t baz(void);

--- a/tests/expectations/extern.compat.c
+++ b/tests/expectations/extern.compat.c
@@ -16,6 +16,8 @@ extern int32_t foo(void);
 
 extern void bar(Normal a);
 
+extern int32_t baz(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/extern.cpp
+++ b/tests/expectations/extern.cpp
@@ -15,4 +15,6 @@ extern int32_t foo();
 
 extern void bar(Normal a);
 
+extern int32_t baz();
+
 } // extern "C"

--- a/tests/expectations/extern.pyx
+++ b/tests/expectations/extern.pyx
@@ -13,3 +13,5 @@ cdef extern from *:
   extern int32_t foo();
 
   extern void bar(Normal a);
+
+  extern int32_t baz();

--- a/tests/expectations/extern_both.c
+++ b/tests/expectations/extern_both.c
@@ -11,3 +11,5 @@ typedef struct Normal {
 extern int32_t foo(void);
 
 extern void bar(struct Normal a);
+
+extern int32_t baz(void);

--- a/tests/expectations/extern_both.compat.c
+++ b/tests/expectations/extern_both.compat.c
@@ -16,6 +16,8 @@ extern int32_t foo(void);
 
 extern void bar(struct Normal a);
 
+extern int32_t baz(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/extern_tag.c
+++ b/tests/expectations/extern_tag.c
@@ -11,3 +11,5 @@ struct Normal {
 extern int32_t foo(void);
 
 extern void bar(struct Normal a);
+
+extern int32_t baz(void);

--- a/tests/expectations/extern_tag.compat.c
+++ b/tests/expectations/extern_tag.compat.c
@@ -16,6 +16,8 @@ extern int32_t foo(void);
 
 extern void bar(struct Normal a);
 
+extern int32_t baz(void);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/tests/expectations/extern_tag.pyx
+++ b/tests/expectations/extern_tag.pyx
@@ -13,3 +13,5 @@ cdef extern from *:
   extern int32_t foo();
 
   extern void bar(Normal a);
+
+  extern int32_t baz();

--- a/tests/rust/extern.rs
+++ b/tests/rust/extern.rs
@@ -9,3 +9,7 @@ extern "C" {
 
     fn bar(a: Normal);
 }
+
+extern {
+    fn baz() -> i32;
+}


### PR DESCRIPTION
As per https://doc.rust-lang.org/reference/items/external-blocks.html#abi

Closes #709