### PR TITLE
Add `cpp_compat` to template.toml

### DIFF
--- a/template.toml
+++ b/template.toml
@@ -24,6 +24,7 @@ using_namespaces = []
 sys_includes = []
 includes = []
 no_includes = false
+# cpp_compat = true
 after_includes = ""
 
 


### PR DESCRIPTION
This adds a mention of `cpp_compat` option to the template file.

#811