### PR TITLE
Honor cbindgen:ignore directives for associated functions and constants

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -541,7 +541,9 @@ impl Parse {
                     if let syn::Type::Path(ref path) = *item_impl.self_ty {
                         if let Some(type_name) = path.path.get_ident() {
                             for method in item_impl.items.iter().filter_map(|item| match item {
-                                syn::ImplItem::Method(method) => Some(method),
+                                syn::ImplItem::Method(method) if !method.should_skip_parsing() => {
+                                    Some(method)
+                                }
                                 _ => None,
                             }) {
                                 self.load_syn_method(
@@ -580,7 +582,11 @@ impl Parse {
         item_impl: &syn::ItemImpl,
     ) {
         let associated_constants = item_impl.items.iter().filter_map(|item| match item {
-            syn::ImplItem::Const(ref associated_constant) => Some(associated_constant),
+            syn::ImplItem::Const(ref associated_constant)
+                if !associated_constant.should_skip_parsing() =>
+            {
+                Some(associated_constant)
+            }
             _ => None,
         });
         self.load_syn_assoc_consts(

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -282,6 +282,7 @@ impl_syn_item_helper!(syn::ItemUse);
 impl_syn_item_helper!(syn::ItemStatic);
 impl_syn_item_helper!(syn::ItemConst);
 impl_syn_item_helper!(syn::ItemFn);
+impl_syn_item_helper!(syn::ImplItemConst);
 impl_syn_item_helper!(syn::ImplItemMethod);
 impl_syn_item_helper!(syn::ItemMod);
 impl_syn_item_helper!(syn::ItemForeignMod);

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -100,6 +100,9 @@ fn is_skip_item_attr(attr: &syn::Meta) -> bool {
                 if let syn::Lit::Str(ref content) = name_value.lit {
                     // FIXME(emilio): Maybe should use the general annotation
                     // mechanism, but it seems overkill for this.
+                    if content.value().contains("XXX") {
+                        panic!("*** XXX *** {}", content.value());
+                    }
                     if content.value().trim() == "cbindgen:ignore" {
                         return true;
                     }

--- a/tests/expectations/ignore.c
+++ b/tests/expectations/ignore.c
@@ -3,4 +3,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define NO_IGNORE_CONST 0
+
+#define NoIgnoreStructWithImpl_NO_IGNORE_INNER_CONST 0
+
 void no_ignore_root(void);
+
+void no_ignore_associated_method(void);

--- a/tests/expectations/ignore.compat.c
+++ b/tests/expectations/ignore.compat.c
@@ -3,11 +3,17 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#define NO_IGNORE_CONST 0
+
+#define NoIgnoreStructWithImpl_NO_IGNORE_INNER_CONST 0
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
 void no_ignore_root(void);
+
+void no_ignore_associated_method(void);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/ignore.cpp
+++ b/tests/expectations/ignore.cpp
@@ -4,8 +4,14 @@
 #include <ostream>
 #include <new>
 
+constexpr static const uint32_t NO_IGNORE_CONST = 0;
+
+constexpr static const uint32_t NoIgnoreStructWithImpl_NO_IGNORE_INNER_CONST = 0;
+
 extern "C" {
 
 void no_ignore_root();
+
+void no_ignore_associated_method();
 
 }  // extern "C"

--- a/tests/expectations/ignore.pyx
+++ b/tests/expectations/ignore.pyx
@@ -6,4 +6,10 @@ cdef extern from *:
 
 cdef extern from *:
 
+  const uint32_t NO_IGNORE_CONST # = 0
+
+  const uint32_t NoIgnoreStructWithImpl_NO_IGNORE_INNER_CONST # = 0
+
   void no_ignore_root();
+
+  void no_ignore_associated_method();

--- a/tests/rust/ignore.rs
+++ b/tests/rust/ignore.rs
@@ -10,3 +10,38 @@ pub extern "C" fn another_root() {}
 
 #[no_mangle]
 pub extern "C" fn no_ignore_root() {}
+
+/// cbindgen:ignore
+#[repr(C)]
+pub struct IgnoredStruct {}
+
+pub struct IgnoredStructImpl;
+
+/// cbindgen:ignore
+impl IgnoredStructImpl {}
+
+/// cbindgen:ignore
+pub const IGNORED_CONST: u32 = 0;
+
+pub const NOT_IGNORED_CONST: u32 = 0;
+
+pub struct StructWithIgnoredImplMembers;
+
+impl StructWithIgnoredImplMembers {
+    /// cbindgen:ignore
+    #[no_mangle]
+    pub extern "C" fn ignored_associated_method() {}
+
+    #[no_mangle]
+    pub extern "C" fn no_ignore_associated_method() {}
+
+    /// cbindgen:ignore
+    pub const IGNORED_INNER_CONST: u32 = 0;
+
+    pub const NOT_IGNORED_INNER_CONST: u32 = 0;
+}
+
+/// cbindgen:ignore
+enum IgnoredEnum {}
+
+enum NotIgnoredEnum {}

--- a/tests/rust/ignore.rs
+++ b/tests/rust/ignore.rs
@@ -13,35 +13,40 @@ pub extern "C" fn no_ignore_root() {}
 
 /// cbindgen:ignore
 #[repr(C)]
-pub struct IgnoredStruct {}
+pub struct IgnoreStruct {}
 
-pub struct IgnoredStructImpl;
-
-/// cbindgen:ignore
-impl IgnoredStructImpl {}
+pub struct IgnoreStructWithImpl;
 
 /// cbindgen:ignore
-pub const IGNORED_CONST: u32 = 0;
-
-pub const NOT_IGNORED_CONST: u32 = 0;
-
-pub struct StructWithIgnoredImplMembers;
-
-impl StructWithIgnoredImplMembers {
-    /// XXX associated method cbindgen:ignore
+impl IgnoreStructWithImpl {
     #[no_mangle]
-    pub extern "C" fn ignored_associated_method() {}
+    pub extern "C" fn ignore_associated_method() {}
+
+    pub const IGNORE_INNER_CONST: u32 = 0;
+}
+
+/// cbindgen:ignore
+pub const IGNORE_CONST: u32 = 0;
+
+pub const NO_IGNORE_CONST: u32 = 0;
+
+pub struct NoIgnoreStructWithImpl;
+
+impl NoIgnoreStructWithImpl {
+    /// cbindgen:ignore
+    #[no_mangle]
+    pub extern "C" fn ignore_associated_method() {}
 
     #[no_mangle]
     pub extern "C" fn no_ignore_associated_method() {}
 
-    /// XXX associated constant cbindgen:ignore
-    pub const IGNORED_INNER_CONST: u32 = 0;
+    /// cbindgen:ignore
+    pub const IGNORE_INNER_CONST: u32 = 0;
 
-    pub const NOT_IGNORED_INNER_CONST: u32 = 0;
+    pub const NO_IGNORE_INNER_CONST: u32 = 0;
 }
 
 /// cbindgen:ignore
-enum IgnoredEnum {}
+enum IgnoreEnum {}
 
-enum NotIgnoredEnum {}
+enum NoIgnoreEnum {}

--- a/tests/rust/ignore.rs
+++ b/tests/rust/ignore.rs
@@ -28,14 +28,14 @@ pub const NOT_IGNORED_CONST: u32 = 0;
 pub struct StructWithIgnoredImplMembers;
 
 impl StructWithIgnoredImplMembers {
-    /// cbindgen:ignore
+    /// XXX associated method cbindgen:ignore
     #[no_mangle]
     pub extern "C" fn ignored_associated_method() {}
 
     #[no_mangle]
     pub extern "C" fn no_ignore_associated_method() {}
 
-    /// cbindgen:ignore
+    /// XXX associated constant cbindgen:ignore
     pub const IGNORED_INNER_CONST: u32 = 0;
 
     pub const NOT_IGNORED_INNER_CONST: u32 = 0;


### PR DESCRIPTION
Fix for https://github.com/mozilla/cbindgen/issues/947

Add missing checks so that cbindgen honors `cbindgen:ignore` directives for associated functions and constants declared inside a struct impl.