### PR TITLE
Rename duplicate crate in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,10 @@ required-features = ["clap"]
 [lib]
 name = "cbindgen"
 path = "src/lib.rs"
+
+[workspace]
+exclude = [
+  "tests/depfile/single_crate",
+  "tests/depfile/single_crate_config",
+  "tests/depfile/single_crate_default_config"
+]

--- a/tests/depfile/single_crate_config/Cargo.lock
+++ b/tests/depfile/single_crate_config/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "single_crate"
+name = "single_crate_config"
 version = "0.1.0"

--- a/tests/depfile/single_crate_config/Cargo.toml
+++ b/tests/depfile/single_crate_config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "single_crate"
+name = "single_crate_config"
 version = "0.1.0"
 authors = ["cbindgen"]
 

--- a/tests/depfile/single_crate_default_config/Cargo.lock
+++ b/tests/depfile/single_crate_default_config/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "single_crate"
+name = "single_crate_default_config"
 version = "0.1.0"

--- a/tests/depfile/single_crate_default_config/Cargo.toml
+++ b/tests/depfile/single_crate_default_config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "single_crate"
+name = "single_crate_default_config"
 version = "0.1.0"
 authors = ["cbindgen"]
 


### PR DESCRIPTION
Otherwise, `cargo` prints a warning when using `cbindgen` as a `build-dependency` in my workspace:

```
warning: skipping duplicate package `single_crate` found at `/Users/gferon/.cargo/git/checkouts/cbindgen-4f7d248bb26fc43d/10f32b0/tests/depfile/single_crate`
warning: skipping duplicate package `single_crate` found at `/Users/gferon/.cargo/git/checkouts/cbindgen-4f7d248bb26fc43d/10f32b0/tests/depfile/single_crate_default_config`
```