### PR TITLE
Revert accidentally committed debug code

### DIFF
--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -100,9 +100,6 @@ fn is_skip_item_attr(attr: &syn::Meta) -> bool {
                 if let syn::Lit::Str(ref content) = name_value.lit {
                     // FIXME(emilio): Maybe should use the general annotation
                     // mechanism, but it seems overkill for this.
-                    if content.value().contains("XXX") {
-                        panic!("*** XXX *** {}", content.value());
-                    }
                     if content.value().trim() == "cbindgen:ignore" {
                         return true;
                     }


### PR DESCRIPTION
As per title, remove debugging code accidentally introduced by https://github.com/mozilla/cbindgen/pull/949