### PR TITLE
Update tests.rs to use pretty_assertions for readable diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "heck",
  "indexmap",
  "log",
+ "pretty_assertions",
  "proc-macro2",
  "quote",
  "serde",
@@ -132,6 +133,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "equivalent"
@@ -256,6 +263,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -546,3 +563,9 @@ checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ toml = "0.8.8"
 proc-macro2 = "1.0.60"
 quote = "1"
 heck = "0.4"
+pretty_assertions = "1.4.0"
 
 [dependencies.syn]
 version = "1.0.88"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ toml = "0.8.8"
 proc-macro2 = "1.0.60"
 quote = "1"
 heck = "0.4"
-pretty_assertions = "1.4.0"
 
 [dependencies.syn]
 version = "1.0.88"
@@ -38,6 +37,7 @@ features = ["clone-impls", "extra-traits", "fold", "full", "parsing", "printing"
 
 [dev-dependencies]
 serial_test = { version = "2.0.0", default-features = false }
+pretty_assertions = "1.4.0"
 
 [features]
 default =  ["clap"]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 use std::process::Command;
 use std::{env, fs, str};
 
+use pretty_assertions::assert_eq;
+
 // Set automatically by cargo for integration tests
 static CBINDGEN_PATH: &str = env!("CARGO_BIN_EXE_cbindgen");
 
@@ -282,8 +284,11 @@ fn run_compile_test(
         }
     } else {
         if env::var_os("CBINDGEN_TEST_VERIFY").is_some() {
+            use std::str::from_utf8;
             let prev_cbindgen_output = fs::read(&generated_file).unwrap();
-            assert_eq!(cbindgen_output, prev_cbindgen_output);
+            let cbindgen_output = from_utf8(&cbindgen_output).unwrap();
+            let prev_cbindgen_output = from_utf8(&prev_cbindgen_output).unwrap();
+            assert_eq!(prev_cbindgen_output, cbindgen_output);
         } else {
             fs::write(&generated_file, &cbindgen_output).unwrap();
         }


### PR DESCRIPTION
The `pretty_assert` package makes it much (much) easier to compare expected vs. actual output when a test fails. Example:
![image](https://github.com/mozilla/cbindgen/assets/9323865/816d33b0-7313-4e1b-af4d-f7dc7db88232)
