### PR TITLE
Handle constants of nested transparent types

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -663,14 +663,13 @@ impl Constant {
             Cow::Owned(format!("{}_{}", associated_name, self.export_name()))
         };
 
-        let value = match self.value {
-            Literal::Struct {
-                ref fields,
-                ref path,
-                ..
-            } if out.bindings().struct_is_transparent(path) => fields.iter().next().unwrap().1,
-            _ => &self.value,
-        };
+        let mut value = &self.value;
+        while let Literal::Struct { path, fields, .. } = value {
+            if !out.bindings().struct_is_transparent(path) {
+                break;
+            }
+            value = fields.iter().next().unwrap().1
+        }
 
         language_backend.write_documentation(out, &self.documentation);
 

--- a/tests/expectations/const_transparent.compat.c
+++ b/tests/expectations/const_transparent.compat.c
@@ -3,6 +3,17 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef uint8_t Transparent;
+typedef uint8_t TransparentStruct;
+#define TransparentStruct_ASSOC_STRUCT_FOO 1
+#define TransparentStruct_ASSOC_STRUCT_BAR 2
 
-#define FOO 0
+
+typedef uint8_t TransparentTupleStruct;
+
+#define STRUCT_FOO 4
+
+#define STRUCT_BAR 5
+
+
+
+

--- a/tests/expectations/const_transparent.cpp
+++ b/tests/expectations/const_transparent.cpp
@@ -4,6 +4,23 @@
 #include <ostream>
 #include <new>
 
-using Transparent = uint8_t;
+template<typename T>
+using Wrapper = T;
 
-constexpr static const Transparent FOO = 0;
+using TransparentStruct = uint8_t;
+constexpr static const int64_t TransparentStruct_ASSOC_STRUCT_FOO = 1;
+constexpr static const TransparentStruct TransparentStruct_ASSOC_STRUCT_BAR = 2;
+constexpr static const Wrapper<TransparentStruct> TransparentStruct_ASSOC_STRUCT_BAZ = 3;
+
+using TransparentTupleStruct = uint8_t;
+
+template<typename T>
+using TransparentStructWithErasedField = Wrapper<T>;
+
+constexpr static const TransparentStruct STRUCT_FOO = 4;
+
+constexpr static const TransparentTupleStruct STRUCT_BAR = 5;
+
+constexpr static const Wrapper<TransparentStruct> STRUCT_BAZ = 6;
+
+constexpr static const TransparentStructWithErasedField<TransparentStruct> COMPLEX = 7;

--- a/tests/expectations/const_transparent.pyx
+++ b/tests/expectations/const_transparent.pyx
@@ -6,6 +6,17 @@ cdef extern from *:
 
 cdef extern from *:
 
-  ctypedef uint8_t Transparent;
+  ctypedef uint8_t TransparentStruct;
+  const int64_t TransparentStruct_ASSOC_STRUCT_FOO # = 1
+  const TransparentStruct TransparentStruct_ASSOC_STRUCT_BAR # = 2
 
-  const Transparent FOO # = 0
+
+  ctypedef uint8_t TransparentTupleStruct;
+
+  const TransparentStruct STRUCT_FOO # = 4
+
+  const TransparentTupleStruct STRUCT_BAR # = 5
+
+
+
+

--- a/tests/rust/const_transparent.rs
+++ b/tests/rust/const_transparent.rs
@@ -1,4 +1,32 @@
 #[repr(transparent)]
-struct Transparent { field: u8 }
+struct TransparentStruct { field: u8 }
 
-pub const FOO: Transparent = Transparent { field: 0 };
+impl TransparentStruct {
+    pub const ASSOC_STRUCT_FOO: i64 = 1;
+    pub const ASSOC_STRUCT_BAR: TransparentStruct = TransparentStruct { field: 2 };
+
+    // TODO: Only C++ supports template constants so far.
+    pub const ASSOC_STRUCT_BAZ: Wrapper<TransparentStruct> = Wrapper { field: TransparentStruct { field: 3 } };
+}
+
+#[repr(transparent)]
+struct TransparentTupleStruct(u8);
+
+#[repr(transparent)]
+struct Wrapper<T> { field: T }
+
+pub const STRUCT_FOO: TransparentStruct = TransparentStruct { field: 4 };
+pub const STRUCT_BAR: TransparentTupleStruct = TransparentTupleStruct(5);
+
+// TODO: Only C++ supports template constants so far.
+pub const STRUCT_BAZ: Wrapper<TransparentStruct> = Wrapper { field: TransparentStruct { field: 6 } };
+
+#[repr(transparent)]
+struct TransparentStructWithErasedField<T> {
+    field: Wrapper<T>,
+}
+
+// TODO: Only C++ supports template constants so far.
+pub const COMPLEX: TransparentStructWithErasedField<TransparentStruct> = TransparentStructWithErasedField {
+    field: Wrapper { field: TransparentStruct { field: 7 } }
+};


### PR DESCRIPTION
When defining a constant of multiply-nested transparent struct type, the struct is reduced to typedefs and so the extra layers of constant initializer need to be removed. The existing code only removed one layer. Fixed by changing the check to a loop.

Without the fix, a declaration like this:
```rust
#[repr(transparent)]
struct TransparentStruct { field: u8 }

#[repr(transparent)]
struct Foo<T> { field: T }

#[repr(transparent)]
struct Bar<T> {
    field: Foo<T>,
}

pub const BAR: Bar<TransparentStruct> =
    Bar { field: Foo { field: TransparentStruct { field: 7 } } };
```

exports as 
```cpp
constexpr static const Bar<TransparentStruct> BAR =
    Foo { /* .field = */ TransparentStruct{ /* .field = */ 7 } };
```
instead of the desired
```cpp
constexpr static const Bar<TransparentStruct> BAR = 7;
```