### PR TITLE
Support generics with defaulted args

### DIFF
--- a/tests/expectations/generic_defaults.c
+++ b/tests/expectations/generic_defaults.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef int16_t Foo_i16;
+
+typedef int32_t Foo_i32;
+
+typedef struct {
+  Foo_i32 f;
+  uint32_t p;
+} Bar_i32__u32;
+
+typedef int64_t Foo_i64;
+
+typedef Foo_i64 Baz_i64;
+
+void foo_root(Foo_i16 f, Bar_i32__u32 b, Baz_i64 z);

--- a/tests/expectations/generic_defaults.compat.c
+++ b/tests/expectations/generic_defaults.compat.c
@@ -1,0 +1,27 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef int16_t Foo_i16;
+
+typedef int32_t Foo_i32;
+
+typedef struct {
+  Foo_i32 f;
+  uint32_t p;
+} Bar_i32__u32;
+
+typedef int64_t Foo_i64;
+
+typedef Foo_i64 Baz_i64;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void foo_root(Foo_i16 f, Bar_i32__u32 b, Baz_i64 z);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tests/expectations/generic_defaults.cpp
+++ b/tests/expectations/generic_defaults.cpp
@@ -1,0 +1,23 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+template<typename T, typename P = void>
+using Foo = T;
+
+template<typename T, typename P>
+struct Bar {
+  Foo<T> f;
+  P p;
+};
+
+template<typename T>
+using Baz = Foo<T>;
+
+extern "C" {
+
+void foo_root(Foo<int16_t> f, Bar<int32_t, uint32_t> b, Baz<int64_t> z);
+
+}  // extern "C"

--- a/tests/expectations/generic_defaults.pyx
+++ b/tests/expectations/generic_defaults.pyx
@@ -1,0 +1,21 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef int16_t Foo_i16;
+
+  ctypedef int32_t Foo_i32;
+
+  ctypedef struct Bar_i32__u32:
+    Foo_i32 f;
+    uint32_t p;
+
+  ctypedef int64_t Foo_i64;
+
+  ctypedef Foo_i64 Baz_i64;
+
+  void foo_root(Foo_i16 f, Bar_i32__u32 b, Baz_i64 z);

--- a/tests/expectations/generic_defaults_both.c
+++ b/tests/expectations/generic_defaults_both.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef int16_t Foo_i16;
+
+typedef int32_t Foo_i32;
+
+typedef struct Bar_i32__u32 {
+  Foo_i32 f;
+  uint32_t p;
+} Bar_i32__u32;
+
+typedef int64_t Foo_i64;
+
+typedef Foo_i64 Baz_i64;
+
+void foo_root(Foo_i16 f, struct Bar_i32__u32 b, Baz_i64 z);

--- a/tests/expectations/generic_defaults_both.compat.c
+++ b/tests/expectations/generic_defaults_both.compat.c
@@ -1,0 +1,27 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef int16_t Foo_i16;
+
+typedef int32_t Foo_i32;
+
+typedef struct Bar_i32__u32 {
+  Foo_i32 f;
+  uint32_t p;
+} Bar_i32__u32;
+
+typedef int64_t Foo_i64;
+
+typedef Foo_i64 Baz_i64;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void foo_root(Foo_i16 f, struct Bar_i32__u32 b, Baz_i64 z);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tests/expectations/generic_defaults_tag.c
+++ b/tests/expectations/generic_defaults_tag.c
@@ -1,0 +1,19 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef int16_t Foo_i16;
+
+typedef int32_t Foo_i32;
+
+struct Bar_i32__u32 {
+  Foo_i32 f;
+  uint32_t p;
+};
+
+typedef int64_t Foo_i64;
+
+typedef Foo_i64 Baz_i64;
+
+void foo_root(Foo_i16 f, struct Bar_i32__u32 b, Baz_i64 z);

--- a/tests/expectations/generic_defaults_tag.compat.c
+++ b/tests/expectations/generic_defaults_tag.compat.c
@@ -1,0 +1,27 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef int16_t Foo_i16;
+
+typedef int32_t Foo_i32;
+
+struct Bar_i32__u32 {
+  Foo_i32 f;
+  uint32_t p;
+};
+
+typedef int64_t Foo_i64;
+
+typedef Foo_i64 Baz_i64;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void foo_root(Foo_i16 f, struct Bar_i32__u32 b, Baz_i64 z);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tests/expectations/generic_defaults_tag.pyx
+++ b/tests/expectations/generic_defaults_tag.pyx
@@ -1,0 +1,21 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef int16_t Foo_i16;
+
+  ctypedef int32_t Foo_i32;
+
+  cdef struct Bar_i32__u32:
+    Foo_i32 f;
+    uint32_t p;
+
+  ctypedef int64_t Foo_i64;
+
+  ctypedef Foo_i64 Baz_i64;
+
+  void foo_root(Foo_i16 f, Bar_i32__u32 b, Baz_i64 z);

--- a/tests/rust/generic_defaults.rs
+++ b/tests/rust/generic_defaults.rs
@@ -1,0 +1,16 @@
+#[repr(transparent)]
+pub struct Foo<T, P = c_void> {
+    field: T,
+    _phantom: std::marker::PhantomData<P>,
+}
+
+#[repr(C)]
+pub struct Bar<T, P> {
+    f: Foo<T>,
+    p: P,
+}
+
+pub type Baz<T> = Foo<T>;
+
+#[no_mangle]
+pub extern "C" fn foo_root(f: Foo<i16>, b: Bar<i32, u32>, z: Baz<i64>) {}


### PR DESCRIPTION
Rust allows generics with defaulted arguments, such as:
```rust
#[repr(transparent)]
pub struct Foo<T, P = c_void> {
    field: T,
    _phantom: std::marker::PhantomData<P>,
}
```
However, any usage that actually relies on such default(s) can trigger assertion failures, e.g.
```rust
#[repr(C)]
pub struct Bar<T> {
    f: Foo<T>,
}
```
or 
```rust
pub type Baz<T> = Foo<T>;
```
Fails with
```
cbindgen failed: None with error: thread 'main' panicked at src/bindgen/ir/generic_path.rs:85:9:
Foo has 2 params but is being instantiated with 1 values
stack backtrace:
   0: rust_begin_unwind
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/core/src/panicking.rs:72:14
   2: cbindgen::bindgen::ir::generic_path::GenericParams::call
             at ./src/bindgen/ir/generic_path.rs:85:9
   3: <cbindgen::bindgen::ir::structure::Struct as cbindgen::bindgen::ir::item::Item>::instantiate_monomorph
             at ./src/bindgen/ir/structure.rs:372:24
   4: cbindgen::bindgen::ir::ty::Type::add_monomorphs
             at ./src/bindgen/ir/ty.rs:868:25
   5: cbindgen::bindgen::ir::function::Function::add_monomorphs
             at ./src/bindgen/ir/function.rs:128:13
   6: cbindgen::bindgen::library::Library::instantiate_monomorphs
             at ./src/bindgen/library.rs:410:13
   7: cbindgen::bindgen::library::Library::generate
             at ./src/bindgen/library.rs:73:13
```
This PR fixes the problem by capturing generic parameter default values at parse time, and using them to "pad" the list of generic arguments if the latter is too short.