### PR TITLE
Generalize Item to expose documentation and generic params

### DIFF
--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -574,6 +574,10 @@ impl Item for Constant {
         &mut self.annotations
     }
 
+    fn documentation(&self) -> &Documentation {
+        &self.documentation
+    }
+
     fn container(&self) -> ItemContainer {
         ItemContainer::Constant(self.clone())
     }
@@ -588,6 +592,10 @@ impl Item for Constant {
 
     fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
         self.ty.resolve_declaration_types(resolver);
+    }
+
+    fn generic_params(&self) -> Option<&GenericParams> {
+        None
     }
 }
 
@@ -672,7 +680,7 @@ impl Constant {
             _ => &self.value,
         };
 
-        language_backend.write_documentation(out, &self.documentation);
+        language_backend.write_documentation(out, self.documentation());
 
         let allow_constexpr = config.constant.allow_constexpr && self.value.can_be_constexpr();
         match config.language {

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -318,7 +318,7 @@ impl Enum {
     }
 
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
-        if self.generic_params.len() > 0 {
+        if self.is_generic() {
             return;
         }
 
@@ -467,6 +467,10 @@ impl Item for Enum {
         &mut self.annotations
     }
 
+    fn documentation(&self) -> &Documentation {
+        &self.documentation
+    }
+
     fn container(&self) -> ItemContainer {
         ItemContainer::Enum(self.clone())
     }
@@ -490,6 +494,10 @@ impl Item for Enum {
         for &mut ref mut var in &mut self.variants {
             var.resolve_declaration_types(resolver);
         }
+    }
+
+    fn generic_params(&self) -> Option<&GenericParams> {
+        Some(&self.generic_params)
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -5,7 +5,9 @@
 use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
-use crate::bindgen::ir::{AnnotationSet, Cfg, Documentation, Item, ItemContainer, Path, Type};
+use crate::bindgen::ir::{
+    AnnotationSet, Cfg, Documentation, GenericParams, Item, ItemContainer, Path, Type,
+};
 use crate::bindgen::library::Library;
 
 #[derive(Debug, Clone)]
@@ -87,6 +89,10 @@ impl Item for Static {
         &mut self.annotations
     }
 
+    fn documentation(&self) -> &Documentation {
+        &self.documentation
+    }
+
     fn container(&self) -> ItemContainer {
         ItemContainer::Static(self.clone())
     }
@@ -97,6 +103,10 @@ impl Item for Static {
 
     fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
         self.ty.resolve_declaration_types(resolver);
+    }
+
+    fn generic_params(&self) -> Option<&GenericParams> {
+        None
     }
 
     fn add_dependencies(&self, library: &Library, out: &mut Dependencies) {

--- a/src/bindgen/ir/item.rs
+++ b/src/bindgen/ir/item.rs
@@ -9,8 +9,8 @@ use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Constant, Enum, GenericArgument, OpaqueItem, Path, Static, Struct, Typedef,
-    Union,
+    AnnotationSet, Cfg, Constant, Documentation, Enum, GenericArgument, GenericParams, OpaqueItem,
+    Path, Static, Struct, Typedef, Union,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::monomorph::Monomorphs;
@@ -27,6 +27,7 @@ pub trait Item {
     fn cfg(&self) -> Option<&Cfg>;
     fn annotations(&self) -> &AnnotationSet;
     fn annotations_mut(&mut self) -> &mut AnnotationSet;
+    fn documentation(&self) -> &Documentation;
 
     fn container(&self) -> ItemContainer;
 
@@ -36,6 +37,13 @@ pub trait Item {
     fn resolve_declaration_types(&mut self, _resolver: &DeclarationTypeResolver) {
         unimplemented!()
     }
+    fn generic_params(&self) -> Option<&GenericParams>;
+
+    fn is_generic(&self) -> bool {
+        self.generic_params()
+            .is_some_and(|params| !params.is_empty())
+    }
+
     fn rename_for_config(&mut self, _config: &Config) {}
     fn add_dependencies(&self, _library: &Library, _out: &mut Dependencies) {}
     fn instantiate_monomorph(

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -78,12 +78,20 @@ impl Item for OpaqueItem {
         &mut self.annotations
     }
 
+    fn documentation(&self) -> &Documentation {
+        &self.documentation
+    }
+
     fn container(&self) -> ItemContainer {
         ItemContainer::OpaqueItem(self.clone())
     }
 
     fn collect_declaration_types(&self, resolver: &mut DeclarationTypeResolver) {
         resolver.add_struct(&self.path);
+    }
+
+    fn generic_params(&self) -> Option<&GenericParams> {
+        Some(&self.generic_params)
     }
 
     fn rename_for_config(&mut self, config: &Config) {
@@ -98,11 +106,7 @@ impl Item for OpaqueItem {
         library: &Library,
         out: &mut Monomorphs,
     ) {
-        assert!(
-            !self.generic_params.is_empty(),
-            "{} is not generic",
-            self.path
-        );
+        assert!(self.is_generic(), "{} is not generic", self.path);
 
         // We can be instantiated with less generic params because of default
         // template parameters, or because of empty types that we remove during

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -150,10 +150,6 @@ impl Struct {
         }
     }
 
-    pub fn is_generic(&self) -> bool {
-        self.generic_params.len() > 0
-    }
-
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
         // Generic structs can instantiate monomorphs only once they've been
         // instantiated. See `instantiate_monomorph` for more details.
@@ -266,6 +262,10 @@ impl Item for Struct {
         &mut self.annotations
     }
 
+    fn documentation(&self) -> &Documentation {
+        &self.documentation
+    }
+
     fn container(&self) -> ItemContainer {
         ItemContainer::Struct(self.clone())
     }
@@ -282,6 +282,10 @@ impl Item for Struct {
         for field in &mut self.fields {
             field.ty.resolve_declaration_types(resolver);
         }
+    }
+
+    fn generic_params(&self) -> Option<&GenericParams> {
+        Some(&self.generic_params)
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -89,18 +89,12 @@ impl Typedef {
         }
     }
 
-    pub fn is_generic(&self) -> bool {
-        self.generic_params.len() > 0
-    }
-
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
         // Generic structs can instantiate monomorphs only once they've been
         // instantiated. See `instantiate_monomorph` for more details.
-        if self.is_generic() {
-            return;
+        if !self.is_generic() {
+            self.aliased.add_monomorphs(library, out);
         }
-
-        self.aliased.add_monomorphs(library, out);
     }
 
     pub fn mangle_paths(&mut self, monomorphs: &Monomorphs) {
@@ -129,6 +123,10 @@ impl Item for Typedef {
         &mut self.annotations
     }
 
+    fn documentation(&self) -> &Documentation {
+        &self.documentation
+    }
+
     fn container(&self) -> ItemContainer {
         ItemContainer::Typedef(self.clone())
     }
@@ -139,6 +137,10 @@ impl Item for Typedef {
 
     fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
         self.aliased.resolve_declaration_types(resolver);
+    }
+
+    fn generic_params(&self) -> Option<&GenericParams> {
+        Some(&self.generic_params)
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -100,10 +100,6 @@ impl Union {
         }
     }
 
-    pub fn is_generic(&self) -> bool {
-        self.generic_params.len() > 0
-    }
-
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
         // Generic unions can instantiate monomorphs only once they've been
         // instantiated. See `instantiate_monomorph` for more details.
@@ -144,6 +140,10 @@ impl Item for Union {
         &mut self.annotations
     }
 
+    fn documentation(&self) -> &Documentation {
+        &self.documentation
+    }
+
     fn container(&self) -> ItemContainer {
         ItemContainer::Union(self.clone())
     }
@@ -156,6 +156,10 @@ impl Item for Union {
         for field in &mut self.fields {
             field.ty.resolve_declaration_types(resolver);
         }
+    }
+
+    fn generic_params(&self) -> Option<&GenericParams> {
+        Some(&self.generic_params)
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -428,11 +428,11 @@ impl Library {
         }
 
         // Remove structs and opaque items that are generic
-        self.opaque_items.filter(|x| x.generic_params.len() > 0);
-        self.structs.filter(|x| x.generic_params.len() > 0);
-        self.unions.filter(|x| x.generic_params.len() > 0);
-        self.enums.filter(|x| x.generic_params.len() > 0);
-        self.typedefs.filter(|x| x.generic_params.len() > 0);
+        self.opaque_items.filter(|x| x.is_generic());
+        self.structs.filter(|x| x.is_generic());
+        self.unions.filter(|x| x.is_generic());
+        self.enums.filter(|x| x.is_generic());
+        self.typedefs.filter(|x| x.is_generic());
 
         // Mangle the paths that remain
         self.unions

--- a/src/bindgen/monomorph.rs
+++ b/src/bindgen/monomorph.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::mem;
 
 use crate::bindgen::ir::{
-    Enum, GenericArgument, GenericPath, OpaqueItem, Path, Struct, Typedef, Union,
+    Enum, GenericArgument, GenericPath, Item, OpaqueItem, Path, Struct, Typedef, Union,
 };
 use crate::bindgen::library::Library;
 
@@ -34,7 +34,7 @@ impl Monomorphs {
     ) {
         let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
-        debug_assert!(generic.generic_params.len() > 0);
+        debug_assert!(generic.is_generic());
         debug_assert!(!self.contains(&replacement_path));
 
         self.replacements
@@ -54,7 +54,7 @@ impl Monomorphs {
     ) {
         let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
-        debug_assert!(generic.generic_params.len() > 0);
+        debug_assert!(generic.is_generic());
         debug_assert!(!self.contains(&replacement_path));
 
         self.replacements
@@ -74,7 +74,7 @@ impl Monomorphs {
     ) {
         let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
-        debug_assert!(generic.generic_params.len() > 0);
+        debug_assert!(generic.is_generic());
         debug_assert!(!self.contains(&replacement_path));
 
         self.replacements
@@ -93,7 +93,7 @@ impl Monomorphs {
     ) {
         let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
-        debug_assert!(generic.generic_params.len() > 0);
+        debug_assert!(generic.is_generic());
         debug_assert!(!self.contains(&replacement_path));
 
         self.replacements
@@ -110,7 +110,7 @@ impl Monomorphs {
     ) {
         let replacement_path = GenericPath::new(generic.path.clone(), arguments);
 
-        debug_assert!(generic.generic_params.len() > 0);
+        debug_assert!(generic.is_generic());
         debug_assert!(!self.contains(&replacement_path));
 
         self.replacements


### PR DESCRIPTION
Small PR to make `Item` more fully capture commonalities of the underlying types.