### PR TITLE
Add support for NonZero<T>

### DIFF
--- a/tests/expectations/nonzero.c
+++ b/tests/expectations/nonzero.c
@@ -29,16 +29,41 @@ typedef struct {
   int64_t h;
   int64_t i;
   const Option_i64 *j;
-} NonZeroTest;
+} NonZeroAliases;
 
-void root(NonZeroTest test,
-          uint8_t a,
-          uint16_t b,
-          uint32_t c,
-          uint64_t d,
-          int8_t e,
-          int16_t f,
-          int32_t g,
-          int64_t h,
-          int64_t i,
-          const Option_i64 *j);
+typedef struct {
+  uint8_t a;
+  uint16_t b;
+  uint32_t c;
+  uint64_t d;
+  int8_t e;
+  int16_t f;
+  int32_t g;
+  int64_t h;
+  int64_t i;
+  const Option_i64 *j;
+} NonZeroGenerics;
+
+void root_nonzero_aliases(NonZeroAliases test,
+                          uint8_t a,
+                          uint16_t b,
+                          uint32_t c,
+                          uint64_t d,
+                          int8_t e,
+                          int16_t f,
+                          int32_t g,
+                          int64_t h,
+                          int64_t i,
+                          const Option_i64 *j);
+
+void root_nonzero_generics(NonZeroGenerics test,
+                           uint8_t a,
+                           uint16_t b,
+                           uint32_t c,
+                           uint64_t d,
+                           int8_t e,
+                           int16_t f,
+                           int32_t g,
+                           int64_t h,
+                           int64_t i,
+                           const Option_i64 *j);

--- a/tests/expectations/nonzero.compat.c
+++ b/tests/expectations/nonzero.compat.c
@@ -29,23 +29,48 @@ typedef struct {
   int64_t h;
   int64_t i;
   const Option_i64 *j;
-} NonZeroTest;
+} NonZeroAliases;
+
+typedef struct {
+  uint8_t a;
+  uint16_t b;
+  uint32_t c;
+  uint64_t d;
+  int8_t e;
+  int16_t f;
+  int32_t g;
+  int64_t h;
+  int64_t i;
+  const Option_i64 *j;
+} NonZeroGenerics;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(NonZeroTest test,
-          uint8_t a,
-          uint16_t b,
-          uint32_t c,
-          uint64_t d,
-          int8_t e,
-          int16_t f,
-          int32_t g,
-          int64_t h,
-          int64_t i,
-          const Option_i64 *j);
+void root_nonzero_aliases(NonZeroAliases test,
+                          uint8_t a,
+                          uint16_t b,
+                          uint32_t c,
+                          uint64_t d,
+                          int8_t e,
+                          int16_t f,
+                          int32_t g,
+                          int64_t h,
+                          int64_t i,
+                          const Option_i64 *j);
+
+void root_nonzero_generics(NonZeroGenerics test,
+                           uint8_t a,
+                           uint16_t b,
+                           uint32_t c,
+                           uint64_t d,
+                           int8_t e,
+                           int16_t f,
+                           int32_t g,
+                           int64_t h,
+                           int64_t i,
+                           const Option_i64 *j);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/nonzero.cpp
+++ b/tests/expectations/nonzero.cpp
@@ -20,7 +20,20 @@ struct NonZeroI64;
 template<typename T = void>
 struct Option;
 
-struct NonZeroTest {
+struct NonZeroAliases {
+  uint8_t a;
+  uint16_t b;
+  uint32_t c;
+  uint64_t d;
+  int8_t e;
+  int16_t f;
+  int32_t g;
+  int64_t h;
+  int64_t i;
+  const Option<int64_t> *j;
+};
+
+struct NonZeroGenerics {
   uint8_t a;
   uint16_t b;
   uint32_t c;
@@ -35,16 +48,28 @@ struct NonZeroTest {
 
 extern "C" {
 
-void root(NonZeroTest test,
-          uint8_t a,
-          uint16_t b,
-          uint32_t c,
-          uint64_t d,
-          int8_t e,
-          int16_t f,
-          int32_t g,
-          int64_t h,
-          int64_t i,
-          const Option<int64_t> *j);
+void root_nonzero_aliases(NonZeroAliases test,
+                          uint8_t a,
+                          uint16_t b,
+                          uint32_t c,
+                          uint64_t d,
+                          int8_t e,
+                          int16_t f,
+                          int32_t g,
+                          int64_t h,
+                          int64_t i,
+                          const Option<int64_t> *j);
+
+void root_nonzero_generics(NonZeroGenerics test,
+                           uint8_t a,
+                           uint16_t b,
+                           uint32_t c,
+                           uint64_t d,
+                           int8_t e,
+                           int16_t f,
+                           int32_t g,
+                           int64_t h,
+                           int64_t i,
+                           const Option<int64_t> *j);
 
 }  // extern "C"

--- a/tests/expectations/nonzero.pyx
+++ b/tests/expectations/nonzero.pyx
@@ -22,7 +22,7 @@ cdef extern from *:
   ctypedef struct Option_i64:
     pass
 
-  ctypedef struct NonZeroTest:
+  ctypedef struct NonZeroAliases:
     uint8_t a;
     uint16_t b;
     uint32_t c;
@@ -34,14 +34,38 @@ cdef extern from *:
     int64_t i;
     const Option_i64 *j;
 
-  void root(NonZeroTest test,
-            uint8_t a,
-            uint16_t b,
-            uint32_t c,
-            uint64_t d,
-            int8_t e,
-            int16_t f,
-            int32_t g,
-            int64_t h,
-            int64_t i,
-            const Option_i64 *j);
+  ctypedef struct NonZeroGenerics:
+    uint8_t a;
+    uint16_t b;
+    uint32_t c;
+    uint64_t d;
+    int8_t e;
+    int16_t f;
+    int32_t g;
+    int64_t h;
+    int64_t i;
+    const Option_i64 *j;
+
+  void root_nonzero_aliases(NonZeroAliases test,
+                            uint8_t a,
+                            uint16_t b,
+                            uint32_t c,
+                            uint64_t d,
+                            int8_t e,
+                            int16_t f,
+                            int32_t g,
+                            int64_t h,
+                            int64_t i,
+                            const Option_i64 *j);
+
+  void root_nonzero_generics(NonZeroGenerics test,
+                             uint8_t a,
+                             uint16_t b,
+                             uint32_t c,
+                             uint64_t d,
+                             int8_t e,
+                             int16_t f,
+                             int32_t g,
+                             int64_t h,
+                             int64_t i,
+                             const Option_i64 *j);

--- a/tests/expectations/nonzero_both.c
+++ b/tests/expectations/nonzero_both.c
@@ -18,7 +18,7 @@ struct NonZeroI64;
 
 typedef struct Option_i64 Option_i64;
 
-typedef struct NonZeroTest {
+typedef struct NonZeroAliases {
   uint8_t a;
   uint16_t b;
   uint32_t c;
@@ -29,16 +29,41 @@ typedef struct NonZeroTest {
   int64_t h;
   int64_t i;
   const struct Option_i64 *j;
-} NonZeroTest;
+} NonZeroAliases;
 
-void root(struct NonZeroTest test,
-          uint8_t a,
-          uint16_t b,
-          uint32_t c,
-          uint64_t d,
-          int8_t e,
-          int16_t f,
-          int32_t g,
-          int64_t h,
-          int64_t i,
-          const struct Option_i64 *j);
+typedef struct NonZeroGenerics {
+  uint8_t a;
+  uint16_t b;
+  uint32_t c;
+  uint64_t d;
+  int8_t e;
+  int16_t f;
+  int32_t g;
+  int64_t h;
+  int64_t i;
+  const struct Option_i64 *j;
+} NonZeroGenerics;
+
+void root_nonzero_aliases(struct NonZeroAliases test,
+                          uint8_t a,
+                          uint16_t b,
+                          uint32_t c,
+                          uint64_t d,
+                          int8_t e,
+                          int16_t f,
+                          int32_t g,
+                          int64_t h,
+                          int64_t i,
+                          const struct Option_i64 *j);
+
+void root_nonzero_generics(struct NonZeroGenerics test,
+                           uint8_t a,
+                           uint16_t b,
+                           uint32_t c,
+                           uint64_t d,
+                           int8_t e,
+                           int16_t f,
+                           int32_t g,
+                           int64_t h,
+                           int64_t i,
+                           const struct Option_i64 *j);

--- a/tests/expectations/nonzero_both.compat.c
+++ b/tests/expectations/nonzero_both.compat.c
@@ -18,7 +18,7 @@ struct NonZeroI64;
 
 typedef struct Option_i64 Option_i64;
 
-typedef struct NonZeroTest {
+typedef struct NonZeroAliases {
   uint8_t a;
   uint16_t b;
   uint32_t c;
@@ -29,23 +29,48 @@ typedef struct NonZeroTest {
   int64_t h;
   int64_t i;
   const struct Option_i64 *j;
-} NonZeroTest;
+} NonZeroAliases;
+
+typedef struct NonZeroGenerics {
+  uint8_t a;
+  uint16_t b;
+  uint32_t c;
+  uint64_t d;
+  int8_t e;
+  int16_t f;
+  int32_t g;
+  int64_t h;
+  int64_t i;
+  const struct Option_i64 *j;
+} NonZeroGenerics;
 
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
-void root(struct NonZeroTest test,
-          uint8_t a,
-          uint16_t b,
-          uint32_t c,
-          uint64_t d,
-          int8_t e,
-          int16_t f,
-          int32_t g,
-          int64_t h,
-          int64_t i,
-          const struct Option_i64 *j);
+void root_nonzero_aliases(struct NonZeroAliases test,
+                          uint8_t a,
+                          uint16_t b,
+                          uint32_t c,
+                          uint64_t d,
+                          int8_t e,
+                          int16_t f,
+                          int32_t g,
+                          int64_t h,
+                          int64_t i,
+                          const struct Option_i64 *j);
+
+void root_nonzero_generics(struct NonZeroGenerics test,
+                           uint8_t a,
+                           uint16_t b,
+                           uint32_t c,
+                           uint64_t d,
+                           int8_t e,
+                           int16_t f,
+                           int32_t g,
+                           int64_t h,
+                           int64_t i,
+                           const struct Option_i64 *j);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/nonzero_tag.c
+++ b/tests/expectations/nonzero_tag.c
@@ -18,7 +18,7 @@ struct NonZeroI64;
 
 struct Option_i64;
 
-struct NonZeroTest {
+struct NonZeroAliases {
   uint8_t a;
   uint16_t b;
   uint32_t c;
@@ -31,14 +31,39 @@ struct NonZeroTest {
   const struct Option_i64 *j;
 };
 
-void root(struct NonZeroTest test,
-          uint8_t a,
-          uint16_t b,
-          uint32_t c,
-          uint64_t d,
-          int8_t e,
-          int16_t f,
-          int32_t g,
-          int64_t h,
-          int64_t i,
-          const struct Option_i64 *j);
+struct NonZeroGenerics {
+  uint8_t a;
+  uint16_t b;
+  uint32_t c;
+  uint64_t d;
+  int8_t e;
+  int16_t f;
+  int32_t g;
+  int64_t h;
+  int64_t i;
+  const struct Option_i64 *j;
+};
+
+void root_nonzero_aliases(struct NonZeroAliases test,
+                          uint8_t a,
+                          uint16_t b,
+                          uint32_t c,
+                          uint64_t d,
+                          int8_t e,
+                          int16_t f,
+                          int32_t g,
+                          int64_t h,
+                          int64_t i,
+                          const struct Option_i64 *j);
+
+void root_nonzero_generics(struct NonZeroGenerics test,
+                           uint8_t a,
+                           uint16_t b,
+                           uint32_t c,
+                           uint64_t d,
+                           int8_t e,
+                           int16_t f,
+                           int32_t g,
+                           int64_t h,
+                           int64_t i,
+                           const struct Option_i64 *j);

--- a/tests/expectations/nonzero_tag.compat.c
+++ b/tests/expectations/nonzero_tag.compat.c
@@ -18,7 +18,20 @@ struct NonZeroI64;
 
 struct Option_i64;
 
-struct NonZeroTest {
+struct NonZeroAliases {
+  uint8_t a;
+  uint16_t b;
+  uint32_t c;
+  uint64_t d;
+  int8_t e;
+  int16_t f;
+  int32_t g;
+  int64_t h;
+  int64_t i;
+  const struct Option_i64 *j;
+};
+
+struct NonZeroGenerics {
   uint8_t a;
   uint16_t b;
   uint32_t c;
@@ -35,17 +48,29 @@ struct NonZeroTest {
 extern "C" {
 #endif // __cplusplus
 
-void root(struct NonZeroTest test,
-          uint8_t a,
-          uint16_t b,
-          uint32_t c,
-          uint64_t d,
-          int8_t e,
-          int16_t f,
-          int32_t g,
-          int64_t h,
-          int64_t i,
-          const struct Option_i64 *j);
+void root_nonzero_aliases(struct NonZeroAliases test,
+                          uint8_t a,
+                          uint16_t b,
+                          uint32_t c,
+                          uint64_t d,
+                          int8_t e,
+                          int16_t f,
+                          int32_t g,
+                          int64_t h,
+                          int64_t i,
+                          const struct Option_i64 *j);
+
+void root_nonzero_generics(struct NonZeroGenerics test,
+                           uint8_t a,
+                           uint16_t b,
+                           uint32_t c,
+                           uint64_t d,
+                           int8_t e,
+                           int16_t f,
+                           int32_t g,
+                           int64_t h,
+                           int64_t i,
+                           const struct Option_i64 *j);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/nonzero_tag.pyx
+++ b/tests/expectations/nonzero_tag.pyx
@@ -22,7 +22,7 @@ cdef extern from *:
   cdef struct Option_i64:
     pass
 
-  cdef struct NonZeroTest:
+  cdef struct NonZeroAliases:
     uint8_t a;
     uint16_t b;
     uint32_t c;
@@ -34,14 +34,38 @@ cdef extern from *:
     int64_t i;
     const Option_i64 *j;
 
-  void root(NonZeroTest test,
-            uint8_t a,
-            uint16_t b,
-            uint32_t c,
-            uint64_t d,
-            int8_t e,
-            int16_t f,
-            int32_t g,
-            int64_t h,
-            int64_t i,
-            const Option_i64 *j);
+  cdef struct NonZeroGenerics:
+    uint8_t a;
+    uint16_t b;
+    uint32_t c;
+    uint64_t d;
+    int8_t e;
+    int16_t f;
+    int32_t g;
+    int64_t h;
+    int64_t i;
+    const Option_i64 *j;
+
+  void root_nonzero_aliases(NonZeroAliases test,
+                            uint8_t a,
+                            uint16_t b,
+                            uint32_t c,
+                            uint64_t d,
+                            int8_t e,
+                            int16_t f,
+                            int32_t g,
+                            int64_t h,
+                            int64_t i,
+                            const Option_i64 *j);
+
+  void root_nonzero_generics(NonZeroGenerics test,
+                             uint8_t a,
+                             uint16_t b,
+                             uint32_t c,
+                             uint64_t d,
+                             int8_t e,
+                             int16_t f,
+                             int32_t g,
+                             int64_t h,
+                             int64_t i,
+                             const Option_i64 *j);

--- a/tests/rust/nonzero.rs
+++ b/tests/rust/nonzero.rs
@@ -1,7 +1,7 @@
 use std::num::*;
 
 #[repr(C)]
-pub struct NonZeroTest {
+pub struct NonZeroAliases {
     pub a: NonZeroU8,
     pub b: NonZeroU16,
     pub c: NonZeroU32,
@@ -15,8 +15,8 @@ pub struct NonZeroTest {
 }
 
 #[no_mangle]
-pub extern "C" fn root(
-    test: NonZeroTest,
+pub extern "C" fn root_nonzero_aliases(
+    test: NonZeroAliases,
     a: NonZeroU8,
     b: NonZeroU16,
     c: NonZeroU32,
@@ -27,4 +27,33 @@ pub extern "C" fn root(
     h: NonZeroI64,
     i: Option<NonZeroI64>,
     j: *const Option<Option<NonZeroI64>>,
+) {}
+
+#[repr(C)]
+pub struct NonZeroGenerics {
+    pub a: NonZero<u8>,
+    pub b: NonZero<u16>,
+    pub c: NonZero<u32>,
+    pub d: NonZero<u64>,
+    pub e: NonZero<i8>,
+    pub f: NonZero<i16>,
+    pub g: NonZero<i32>,
+    pub h: NonZero<i64>,
+    pub i: Option<NonZero<i64>>,
+    pub j: *const Option<Option<NonZero<i64>>>,
+}
+
+#[no_mangle]
+pub extern "C" fn root_nonzero_generics(
+    test: NonZeroGenerics,
+    a: NonZero<u8>,
+    b: NonZero<u16>,
+    c: NonZero<u32>,
+    d: NonZero<u64>,
+    e: NonZero<i8>,
+    f: NonZero<i16>,
+    g: NonZero<i32>,
+    h: NonZero<i64>,
+    i: Option<NonZero<i64>>,
+    j: *const Option<Option<NonZero<i64>>>,
 ) {}


### PR DESCRIPTION
Currently, cbindgen only supports the various `NonZeroXX` type aliases, but not `NonZero<T>` itself. Add that support, and also simplify the handling of types in general.