### PR TITLE
Va list binding compatibility

### DIFF
--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -239,6 +239,10 @@ impl SynFnArgHelpers for syn::FnArg {
             syn::FnArg::Typed(syn::PatType {
                 ref pat, ref ty, ..
             }) => {
+                let ty = match Type::load(ty)? {
+                    Some(x) => x,
+                    None => return Ok(None),
+                };
                 let name = match **pat {
                     syn::Pat::Wild(..) => None,
                     syn::Pat::Ident(syn::PatIdent { ref ident, .. }) => {
@@ -250,10 +254,6 @@ impl SynFnArgHelpers for syn::FnArg {
                             pat
                         ))
                     }
-                };
-                let ty = match Type::load(ty)? {
-                    Some(x) => x,
-                    None => return Ok(None),
                 };
                 if let Type::Array(..) = ty {
                     return Err("Array as function arguments are not supported".to_owned());

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -246,7 +246,11 @@ impl SynFnArgHelpers for syn::FnArg {
                 let name = match **pat {
                     syn::Pat::Wild(..) => None,
                     syn::Pat::Ident(syn::PatIdent { ref ident, .. }) => {
-                        Some(ident.unraw().to_string())
+                        if ty == Type::Primitive(super::PrimitiveType::VaList) {
+                            None
+                        } else {
+                            Some(ident.unraw().to_string())
+                        }
                     }
                     _ => {
                         return Err(format!(

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -218,7 +218,7 @@ impl PrimitiveType {
             PrimitiveType::Float => "float",
             PrimitiveType::Double => "double",
             PrimitiveType::PtrDiffT => "ptrdiff_t",
-            PrimitiveType::VaList => "va_list",
+            PrimitiveType::VaList => "...",
         }
     }
 

--- a/tests/expectations/va_list.c
+++ b/tests/expectations/va_list.c
@@ -3,6 +3,25 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-int32_t va_list_test(va_list ap);
+typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
 
-int32_t va_list_test2(va_list ap);
+typedef int32_t (*VaListFnPtr2)(int32_t count);
+
+typedef struct {
+  int32_t (*fn1)(int32_t count, va_list);
+} Interface_______i32_______i32_______va_list;
+
+typedef struct {
+  int32_t (*fn1)(int32_t count);
+} Interface_______i32_______i32;
+
+int32_t va_list_test(int32_t count, va_list ap);
+
+int32_t va_list_test2(int32_t count, va_list ap);
+
+void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+                     int32_t (*fn2)(int32_t count),
+                     VaListFnPtr fn3,
+                     VaListFnPtr2 fn4,
+                     Interface_______i32_______i32_______va_list fn5,
+                     Interface_______i32_______i32 fn6);

--- a/tests/expectations/va_list.c
+++ b/tests/expectations/va_list.c
@@ -3,23 +3,23 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
+typedef int32_t (*VaListFnPtr)(int32_t count, ...);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
 typedef struct {
-  int32_t (*fn1)(int32_t count, va_list);
+  int32_t (*fn1)(int32_t count, ...);
 } Interface_______i32_______i32_______va_list;
 
 typedef struct {
   int32_t (*fn1)(int32_t count);
 } Interface_______i32_______i32;
 
-int32_t va_list_test(int32_t count, va_list ap);
+int32_t va_list_test(int32_t count, ...);
 
-int32_t va_list_test2(int32_t count, va_list ap);
+int32_t va_list_test2(int32_t count, ...);
 
-void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, ...),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,

--- a/tests/expectations/va_list.compat.c
+++ b/tests/expectations/va_list.compat.c
@@ -3,12 +3,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
+typedef int32_t (*VaListFnPtr)(int32_t count, ...);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
 typedef struct {
-  int32_t (*fn1)(int32_t count, va_list);
+  int32_t (*fn1)(int32_t count, ...);
 } Interface_______i32_______i32_______va_list;
 
 typedef struct {
@@ -19,11 +19,11 @@ typedef struct {
 extern "C" {
 #endif // __cplusplus
 
-int32_t va_list_test(int32_t count, va_list ap);
+int32_t va_list_test(int32_t count, ...);
 
-int32_t va_list_test2(int32_t count, va_list ap);
+int32_t va_list_test2(int32_t count, ...);
 
-void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, ...),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,

--- a/tests/expectations/va_list.cpp
+++ b/tests/expectations/va_list.cpp
@@ -4,10 +4,26 @@
 #include <ostream>
 #include <new>
 
+using VaListFnPtr = int32_t(*)(int32_t count, va_list);
+
+using VaListFnPtr2 = int32_t(*)(int32_t count);
+
+template<typename T>
+struct Interface {
+  T fn1;
+};
+
 extern "C" {
 
-int32_t va_list_test(va_list ap);
+int32_t va_list_test(int32_t count, va_list ap);
 
-int32_t va_list_test2(va_list ap);
+int32_t va_list_test2(int32_t count, va_list ap);
+
+void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+                     int32_t (*fn2)(int32_t count),
+                     VaListFnPtr fn3,
+                     VaListFnPtr2 fn4,
+                     Interface<int32_t(*)(int32_t count, va_list)> fn5,
+                     Interface<int32_t(*)(int32_t count)> fn6);
 
 }  // extern "C"

--- a/tests/expectations/va_list.cpp
+++ b/tests/expectations/va_list.cpp
@@ -4,7 +4,7 @@
 #include <ostream>
 #include <new>
 
-using VaListFnPtr = int32_t(*)(int32_t count, va_list);
+using VaListFnPtr = int32_t(*)(int32_t count, ...);
 
 using VaListFnPtr2 = int32_t(*)(int32_t count);
 
@@ -15,15 +15,15 @@ struct Interface {
 
 extern "C" {
 
-int32_t va_list_test(int32_t count, va_list ap);
+int32_t va_list_test(int32_t count, ...);
 
-int32_t va_list_test2(int32_t count, va_list ap);
+int32_t va_list_test2(int32_t count, ...);
 
-void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, ...),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,
-                     Interface<int32_t(*)(int32_t count, va_list)> fn5,
+                     Interface<int32_t(*)(int32_t count, ...)> fn5,
                      Interface<int32_t(*)(int32_t count)> fn6);
 
 }  // extern "C"

--- a/tests/expectations/va_list.pyx
+++ b/tests/expectations/va_list.pyx
@@ -6,21 +6,21 @@ cdef extern from *:
 
 cdef extern from *:
 
-  ctypedef int32_t (*VaListFnPtr)(int32_t count, va_list);
+  ctypedef int32_t (*VaListFnPtr)(int32_t count, ...);
 
   ctypedef int32_t (*VaListFnPtr2)(int32_t count);
 
   ctypedef struct Interface_______i32_______i32_______va_list:
-    int32_t (*fn1)(int32_t count, va_list);
+    int32_t (*fn1)(int32_t count, ...);
 
   ctypedef struct Interface_______i32_______i32:
     int32_t (*fn1)(int32_t count);
 
-  int32_t va_list_test(int32_t count, va_list ap);
+  int32_t va_list_test(int32_t count, ...);
 
-  int32_t va_list_test2(int32_t count, va_list ap);
+  int32_t va_list_test2(int32_t count, ...);
 
-  void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+  void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, ...),
                        int32_t (*fn2)(int32_t count),
                        VaListFnPtr fn3,
                        VaListFnPtr2 fn4,

--- a/tests/expectations/va_list_both.c
+++ b/tests/expectations/va_list_both.c
@@ -3,23 +3,23 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
+typedef int32_t (*VaListFnPtr)(int32_t count, ...);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
 typedef struct Interface_______i32_______i32_______va_list {
-  int32_t (*fn1)(int32_t count, va_list);
+  int32_t (*fn1)(int32_t count, ...);
 } Interface_______i32_______i32_______va_list;
 
 typedef struct Interface_______i32_______i32 {
   int32_t (*fn1)(int32_t count);
 } Interface_______i32_______i32;
 
-int32_t va_list_test(int32_t count, va_list ap);
+int32_t va_list_test(int32_t count, ...);
 
-int32_t va_list_test2(int32_t count, va_list ap);
+int32_t va_list_test2(int32_t count, ...);
 
-void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, ...),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,

--- a/tests/expectations/va_list_both.c
+++ b/tests/expectations/va_list_both.c
@@ -7,17 +7,13 @@ typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
-typedef struct {
+typedef struct Interface_______i32_______i32_______va_list {
   int32_t (*fn1)(int32_t count, va_list);
 } Interface_______i32_______i32_______va_list;
 
-typedef struct {
+typedef struct Interface_______i32_______i32 {
   int32_t (*fn1)(int32_t count);
 } Interface_______i32_______i32;
-
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
 
 int32_t va_list_test(int32_t count, va_list ap);
 
@@ -27,9 +23,5 @@ void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,
-                     Interface_______i32_______i32_______va_list fn5,
-                     Interface_______i32_______i32 fn6);
-
-#ifdef __cplusplus
-}  // extern "C"
-#endif  // __cplusplus
+                     struct Interface_______i32_______i32_______va_list fn5,
+                     struct Interface_______i32_______i32 fn6);

--- a/tests/expectations/va_list_both.compat.c
+++ b/tests/expectations/va_list_both.compat.c
@@ -7,11 +7,11 @@ typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
-typedef struct {
+typedef struct Interface_______i32_______i32_______va_list {
   int32_t (*fn1)(int32_t count, va_list);
 } Interface_______i32_______i32_______va_list;
 
-typedef struct {
+typedef struct Interface_______i32_______i32 {
   int32_t (*fn1)(int32_t count);
 } Interface_______i32_______i32;
 
@@ -27,8 +27,8 @@ void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,
-                     Interface_______i32_______i32_______va_list fn5,
-                     Interface_______i32_______i32 fn6);
+                     struct Interface_______i32_______i32_______va_list fn5,
+                     struct Interface_______i32_______i32 fn6);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/va_list_both.compat.c
+++ b/tests/expectations/va_list_both.compat.c
@@ -3,12 +3,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
+typedef int32_t (*VaListFnPtr)(int32_t count, ...);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
 typedef struct Interface_______i32_______i32_______va_list {
-  int32_t (*fn1)(int32_t count, va_list);
+  int32_t (*fn1)(int32_t count, ...);
 } Interface_______i32_______i32_______va_list;
 
 typedef struct Interface_______i32_______i32 {
@@ -19,11 +19,11 @@ typedef struct Interface_______i32_______i32 {
 extern "C" {
 #endif // __cplusplus
 
-int32_t va_list_test(int32_t count, va_list ap);
+int32_t va_list_test(int32_t count, ...);
 
-int32_t va_list_test2(int32_t count, va_list ap);
+int32_t va_list_test2(int32_t count, ...);
 
-void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, ...),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,

--- a/tests/expectations/va_list_tag.c
+++ b/tests/expectations/va_list_tag.c
@@ -3,23 +3,23 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
+typedef int32_t (*VaListFnPtr)(int32_t count, ...);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
 struct Interface_______i32_______i32_______va_list {
-  int32_t (*fn1)(int32_t count, va_list);
+  int32_t (*fn1)(int32_t count, ...);
 };
 
 struct Interface_______i32_______i32 {
   int32_t (*fn1)(int32_t count);
 };
 
-int32_t va_list_test(int32_t count, va_list ap);
+int32_t va_list_test(int32_t count, ...);
 
-int32_t va_list_test2(int32_t count, va_list ap);
+int32_t va_list_test2(int32_t count, ...);
 
-void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, ...),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,

--- a/tests/expectations/va_list_tag.c
+++ b/tests/expectations/va_list_tag.c
@@ -7,17 +7,13 @@ typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
-typedef struct {
+struct Interface_______i32_______i32_______va_list {
   int32_t (*fn1)(int32_t count, va_list);
-} Interface_______i32_______i32_______va_list;
+};
 
-typedef struct {
+struct Interface_______i32_______i32 {
   int32_t (*fn1)(int32_t count);
-} Interface_______i32_______i32;
-
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
+};
 
 int32_t va_list_test(int32_t count, va_list ap);
 
@@ -27,9 +23,5 @@ void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,
-                     Interface_______i32_______i32_______va_list fn5,
-                     Interface_______i32_______i32 fn6);
-
-#ifdef __cplusplus
-}  // extern "C"
-#endif  // __cplusplus
+                     struct Interface_______i32_______i32_______va_list fn5,
+                     struct Interface_______i32_______i32 fn6);

--- a/tests/expectations/va_list_tag.compat.c
+++ b/tests/expectations/va_list_tag.compat.c
@@ -3,12 +3,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
+typedef int32_t (*VaListFnPtr)(int32_t count, ...);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
 struct Interface_______i32_______i32_______va_list {
-  int32_t (*fn1)(int32_t count, va_list);
+  int32_t (*fn1)(int32_t count, ...);
 };
 
 struct Interface_______i32_______i32 {
@@ -19,11 +19,11 @@ struct Interface_______i32_______i32 {
 extern "C" {
 #endif // __cplusplus
 
-int32_t va_list_test(int32_t count, va_list ap);
+int32_t va_list_test(int32_t count, ...);
 
-int32_t va_list_test2(int32_t count, va_list ap);
+int32_t va_list_test2(int32_t count, ...);
 
-void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, ...),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,

--- a/tests/expectations/va_list_tag.compat.c
+++ b/tests/expectations/va_list_tag.compat.c
@@ -7,13 +7,13 @@ typedef int32_t (*VaListFnPtr)(int32_t count, va_list);
 
 typedef int32_t (*VaListFnPtr2)(int32_t count);
 
-typedef struct {
+struct Interface_______i32_______i32_______va_list {
   int32_t (*fn1)(int32_t count, va_list);
-} Interface_______i32_______i32_______va_list;
+};
 
-typedef struct {
+struct Interface_______i32_______i32 {
   int32_t (*fn1)(int32_t count);
-} Interface_______i32_______i32;
+};
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,8 +27,8 @@ void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
                      int32_t (*fn2)(int32_t count),
                      VaListFnPtr fn3,
                      VaListFnPtr2 fn4,
-                     Interface_______i32_______i32_______va_list fn5,
-                     Interface_______i32_______i32 fn6);
+                     struct Interface_______i32_______i32_______va_list fn5,
+                     struct Interface_______i32_______i32 fn6);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/va_list_tag.pyx
+++ b/tests/expectations/va_list_tag.pyx
@@ -6,21 +6,21 @@ cdef extern from *:
 
 cdef extern from *:
 
-  ctypedef int32_t (*VaListFnPtr)(int32_t count, va_list);
+  ctypedef int32_t (*VaListFnPtr)(int32_t count, ...);
 
   ctypedef int32_t (*VaListFnPtr2)(int32_t count);
 
   cdef struct Interface_______i32_______i32_______va_list:
-    int32_t (*fn1)(int32_t count, va_list);
+    int32_t (*fn1)(int32_t count, ...);
 
   cdef struct Interface_______i32_______i32:
     int32_t (*fn1)(int32_t count);
 
-  int32_t va_list_test(int32_t count, va_list ap);
+  int32_t va_list_test(int32_t count, ...);
 
-  int32_t va_list_test2(int32_t count, va_list ap);
+  int32_t va_list_test2(int32_t count, ...);
 
-  void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, va_list),
+  void va_list_fn_ptrs(int32_t (*fn1)(int32_t count, ...),
                        int32_t (*fn2)(int32_t count),
                        VaListFnPtr fn3,
                        VaListFnPtr2 fn4,

--- a/tests/expectations/va_list_tag.pyx
+++ b/tests/expectations/va_list_tag.pyx
@@ -10,10 +10,10 @@ cdef extern from *:
 
   ctypedef int32_t (*VaListFnPtr2)(int32_t count);
 
-  ctypedef struct Interface_______i32_______i32_______va_list:
+  cdef struct Interface_______i32_______i32_______va_list:
     int32_t (*fn1)(int32_t count, va_list);
 
-  ctypedef struct Interface_______i32_______i32:
+  cdef struct Interface_______i32_______i32:
     int32_t (*fn1)(int32_t count);
 
   int32_t va_list_test(int32_t count, va_list ap);

--- a/tests/rust/va_list.rs
+++ b/tests/rust/va_list.rs
@@ -1,11 +1,30 @@
 use std::ffi::VaList;
 
 #[no_mangle]
-pub unsafe extern "C" fn va_list_test(mut ap: VaList) -> int32_t {
+pub unsafe extern "C" fn va_list_test(count: int32_t, mut ap: VaList) -> int32_t {
     ap.arg()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn va_list_test2(mut ap: ...) -> int32_t {
+pub unsafe extern "C" fn va_list_test2(count: int32_t, mut ap: ...) -> int32_t {
     ap.arg()
+}
+
+type VaListFnPtr = Option<unsafe extern "C" fn(count: int32_t, VaList) -> int32_t>;
+type VaListFnPtr2 = Option<unsafe extern "C" fn(count: int32_t, ...) -> int32_t>;
+
+#[repr(C)]
+struct Interface<T> {
+    fn1: T,
+}
+
+#[no_mangle]
+pub extern "C" fn va_list_fn_ptrs(
+    fn1: Option<unsafe extern "C" fn(count: int32_t, VaList) -> int32_t>,
+    fn2: Option<unsafe extern "C" fn(count: int32_t, ...) -> int32_t>,
+    fn3: VaListFnPtr,
+    fn4: VaListFnPtr2,
+    fn5: Interface<Option<unsafe extern "C" fn(count: int32_t, VaList) -> int32_t>>,
+    fn6: Interface<Option<unsafe extern "C" fn(count: int32_t, ...) -> int32_t>>,
+) {
 }


### PR DESCRIPTION
From what I can tell a `va_list` should be created by calling [`va_start`](https://en.cppreference.com/w/c/variadic/va_start) and no documentation that I could find specifies the use of `va_list` as an argument explicitly. 
Assuming this works, I imagine that some compilers happen to implement `va_list` and `...` the same, but `...` seems the be the specified way.

I haven't done any runtime testing of these changes, so if this is wrong I'd love to know why.

Sources:
* https://en.cppreference.com/w/c/language/variadic
* https://en.cppreference.com/w/cpp/language/variadic_arguments

Related: https://github.com/mozilla/cbindgen/pull/968

Closes: https://github.com/mozilla/cbindgen/issues/891