### PR TITLE
Output condition for globals.

### DIFF
--- a/src/bindgen/language_backend/clike.rs
+++ b/src/bindgen/language_backend/clike.rs
@@ -770,6 +770,9 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
     }
 
     fn write_static<W: Write>(&mut self, out: &mut SourceWriter<W>, s: &Static) {
+        let condition = s.cfg.to_condition(self.config);
+        condition.write_before(self.config, out);
+
         self.write_documentation(out, &s.documentation);
         out.write("extern ");
         if let Type::Ptr { is_const: true, .. } = s.ty {
@@ -778,6 +781,8 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
         }
         cdecl::write_field(self, out, &s.ty, &s.export_name, self.config);
         out.write(";");
+
+        condition.write_after(self.config, out);
     }
 
     fn write_type<W: Write>(&mut self, out: &mut SourceWriter<W>, t: &Type) {

--- a/src/bindgen/language_backend/cython.rs
+++ b/src/bindgen/language_backend/cython.rs
@@ -315,6 +315,9 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
     }
 
     fn write_static<W: Write>(&mut self, out: &mut SourceWriter<W>, s: &Static) {
+        let condition = s.cfg.to_condition(self.config);
+        condition.write_before(self.config, out);
+
         self.write_documentation(out, &s.documentation);
         out.write("extern ");
         if let Type::Ptr { is_const: true, .. } = s.ty {
@@ -323,6 +326,8 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
         }
         cdecl::write_field(self, out, &s.ty, &s.export_name, self.config);
         out.write(";");
+
+        condition.write_after(self.config, out);
     }
 
     fn write_type<W: Write>(&mut self, out: &mut SourceWriter<W>, t: &Type) {

--- a/tests/expectations/cfg.c
+++ b/tests/expectations/cfg.c
@@ -83,6 +83,14 @@ typedef struct {
   float y;
 } Normal;
 
+#if defined(PLATFORM_WIN)
+extern int32_t global_array_with_different_sizes[2];
+#endif
+
+#if defined(PLATFORM_UNIX)
+extern int32_t global_array_with_different_sizes[1];
+#endif
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(FooHandle a, C c);
 #endif

--- a/tests/expectations/cfg.compat.c
+++ b/tests/expectations/cfg.compat.c
@@ -105,6 +105,14 @@ typedef struct {
 extern "C" {
 #endif // __cplusplus
 
+#if defined(PLATFORM_WIN)
+extern int32_t global_array_with_different_sizes[2];
+#endif
+
+#if defined(PLATFORM_UNIX)
+extern int32_t global_array_with_different_sizes[1];
+#endif
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(FooHandle a, C c);
 #endif

--- a/tests/expectations/cfg.cpp
+++ b/tests/expectations/cfg.cpp
@@ -218,6 +218,14 @@ struct Normal {
 
 extern "C" {
 
+#if defined(PLATFORM_WIN)
+extern int32_t global_array_with_different_sizes[2];
+#endif
+
+#if defined(PLATFORM_UNIX)
+extern int32_t global_array_with_different_sizes[1];
+#endif
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(FooHandle a, C c);
 #endif

--- a/tests/expectations/cfg.pyx
+++ b/tests/expectations/cfg.pyx
@@ -62,6 +62,12 @@ cdef extern from *:
     int32_t x;
     float y;
 
+  IF PLATFORM_WIN:
+    extern int32_t global_array_with_different_sizes[2];
+
+  IF PLATFORM_UNIX:
+    extern int32_t global_array_with_different_sizes[1];
+
   IF (PLATFORM_UNIX and X11):
     void root(FooHandle a, C c);
 

--- a/tests/expectations/cfg_both.c
+++ b/tests/expectations/cfg_both.c
@@ -83,6 +83,14 @@ typedef struct Normal {
   float y;
 } Normal;
 
+#if defined(PLATFORM_WIN)
+extern int32_t global_array_with_different_sizes[2];
+#endif
+
+#if defined(PLATFORM_UNIX)
+extern int32_t global_array_with_different_sizes[1];
+#endif
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(struct FooHandle a, union C c);
 #endif

--- a/tests/expectations/cfg_both.compat.c
+++ b/tests/expectations/cfg_both.compat.c
@@ -105,6 +105,14 @@ typedef struct Normal {
 extern "C" {
 #endif // __cplusplus
 
+#if defined(PLATFORM_WIN)
+extern int32_t global_array_with_different_sizes[2];
+#endif
+
+#if defined(PLATFORM_UNIX)
+extern int32_t global_array_with_different_sizes[1];
+#endif
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(struct FooHandle a, union C c);
 #endif

--- a/tests/expectations/cfg_tag.c
+++ b/tests/expectations/cfg_tag.c
@@ -83,6 +83,14 @@ struct Normal {
   float y;
 };
 
+#if defined(PLATFORM_WIN)
+extern int32_t global_array_with_different_sizes[2];
+#endif
+
+#if defined(PLATFORM_UNIX)
+extern int32_t global_array_with_different_sizes[1];
+#endif
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(struct FooHandle a, union C c);
 #endif

--- a/tests/expectations/cfg_tag.compat.c
+++ b/tests/expectations/cfg_tag.compat.c
@@ -105,6 +105,14 @@ struct Normal {
 extern "C" {
 #endif // __cplusplus
 
+#if defined(PLATFORM_WIN)
+extern int32_t global_array_with_different_sizes[2];
+#endif
+
+#if defined(PLATFORM_UNIX)
+extern int32_t global_array_with_different_sizes[1];
+#endif
+
 #if (defined(PLATFORM_UNIX) && defined(X11))
 void root(struct FooHandle a, union C c);
 #endif

--- a/tests/expectations/cfg_tag.pyx
+++ b/tests/expectations/cfg_tag.pyx
@@ -62,6 +62,12 @@ cdef extern from *:
     int32_t x;
     float y;
 
+  IF PLATFORM_WIN:
+    extern int32_t global_array_with_different_sizes[2];
+
+  IF PLATFORM_UNIX:
+    extern int32_t global_array_with_different_sizes[1];
+
   IF (PLATFORM_UNIX and X11):
     void root(FooHandle a, C c);
 

--- a/tests/rust/cfg.rs
+++ b/tests/rust/cfg.rs
@@ -76,3 +76,10 @@ extern "C" {
 
     fn bar(a: Normal);
 }
+
+#[cfg(windows)]
+#[no_mangle]
+pub static mut global_array_with_different_sizes: [i32; 2] = [123, 456];
+#[cfg(unix)]
+#[no_mangle]
+pub static mut global_array_with_different_sizes: [i32; 1] = [7890];


### PR DESCRIPTION
I was getting an error in a global array that has a different size when a feature is enabled.

This PR fixes the issue.