### PR TITLE
Update CHANGES since v0.26.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,13 @@
 # unreleased
 
       * Revert: The `Config` struct now has a private member.
+      * Allow users to specify a crate version for bindings generation (#901).
+      * Update MSRV to 1.70 (#912).
+      * Support #[deprecated] on enum variants (#933).
+      * Support integrating the package_version information in a header file comment (#939).
+      * Add a language backend (#942).
+      * Support generics with defaulted args (#959).
+      * Add `VaList` compatibility (#970).
 
 # 0.26.0
 


### PR DESCRIPTION
Helps for [the comment](https://github.com/mozilla/cbindgen/pull/912#issuecomment-2136195600) in #912.

I had no extensive knowledge about the details of this project before, so I selected some of the PRs since Sep 14, 2023, based on my understanding, and added them to the changelog. I hope this helps the preparations for a new release.