### PR TITLE
Convert config fields header, trailer, after_includes to text fields.

### DIFF
--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -37,7 +37,7 @@ impl Builder {
 
     #[allow(unused)]
     pub fn with_header<S: AsRef<str>>(mut self, header: S) -> Builder {
-        self.config.header = Some(String::from(header.as_ref()));
+        self.config.header = String::from(header.as_ref()).into();
         self
     }
 
@@ -63,13 +63,13 @@ impl Builder {
 
     #[allow(unused)]
     pub fn with_after_include<S: AsRef<str>>(mut self, line: S) -> Builder {
-        self.config.after_includes = Some(String::from(line.as_ref()));
+        self.config.after_includes = String::from(line.as_ref()).into();
         self
     }
 
     #[allow(unused)]
     pub fn with_trailer<S: AsRef<str>>(mut self, trailer: S) -> Builder {
-        self.config.trailer = Some(String::from(trailer.as_ref()));
+        self.config.trailer = String::from(trailer.as_ref()).into();
         self
     }
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -894,6 +894,78 @@ pub struct CythonConfig {
     pub cimports: BTreeMap<String, Vec<String>>,
 }
 
+/// A line field can be a single line `field = "line"` or a struct `field = { language = "C", line = "struct" }`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum Line {
+    AnyBackend(String),
+    WithBackend { language: Language, line: String },
+}
+impl Line {
+    pub fn line_for(&self, target: Language) -> Option<&str> {
+        match *self {
+            Line::AnyBackend(ref line) => Some(line.as_str()),
+            Line::WithBackend { language, ref line } if language == target => Some(line.as_str()),
+            _ => None,
+        }
+    }
+}
+impl From<String> for Line {
+    fn from(value: String) -> Self {
+        Self::AnyBackend(value)
+    }
+}
+
+/// A text field can be a line field or a sequence of lines or structs:
+/// ```toml
+/// field = [
+///    "sequence of lines",
+///    { language = "C", line = "or structs" },
+/// ]
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum Text {
+    Line(Line),
+    Lines(Vec<Line>),
+}
+impl Text {
+    pub fn is_empty(&self) -> bool {
+        match *self {
+            Text::Line(_) => false,
+            Text::Lines(ref lines) => lines.is_empty(),
+        }
+    }
+    pub fn text_for(&self, target: Language) -> Vec<&str> {
+        let mut text = Vec::new();
+        match self {
+            Text::Line(line) => {
+                if let Some(s) = line.line_for(target) {
+                    text.push(s);
+                }
+            }
+            Text::Lines(lines) => {
+                for line in lines.iter() {
+                    if let Some(s) = line.line_for(target) {
+                        text.push(s);
+                    }
+                }
+            }
+        }
+        text
+    }
+}
+impl From<String> for Text {
+    fn from(value: String) -> Self {
+        Self::Line(value.into())
+    }
+}
+impl Default for Text {
+    fn default() -> Self {
+        Self::Lines(Vec::new())
+    }
+}
+
 /// A collection of settings to customize the generated bindings.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -901,15 +973,15 @@ pub struct CythonConfig {
 #[serde(default)]
 pub struct Config {
     /// Optional text to output at the beginning of the file
-    pub header: Option<String>,
+    pub header: Text,
     /// A list of additional includes to put at the beginning of the generated header
     pub includes: Vec<String>,
     /// A list of additional system includes to put at the beginning of the generated header
     pub sys_includes: Vec<String>,
     /// Optional verbatim code added after the include blocks
-    pub after_includes: Option<String>,
+    pub after_includes: Text,
     /// Optional text to output at the end of the file
-    pub trailer: Option<String>,
+    pub trailer: Text,
     /// Optional name to use for an include guard
     pub include_guard: Option<String>,
     /// Add a `#pragma once` guard
@@ -1032,11 +1104,11 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            header: None,
+            header: Text::default(),
             includes: Vec::new(),
             sys_includes: Vec::new(),
-            after_includes: None,
-            trailer: None,
+            after_includes: Text::default(),
+            trailer: Text::default(),
             include_guard: None,
             pragma_once: false,
             autogen_warning: None,

--- a/src/bindgen/language_backend/clike.rs
+++ b/src/bindgen/language_backend/clike.rs
@@ -344,9 +344,9 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
             write!(out, "/* Package version: {} */", package_version);
             out.new_line();
         }
-        if let Some(ref f) = self.config.header {
+        for line in self.config.header.text_for(self.config.language) {
             out.new_line_if_not_start();
-            write!(out, "{}", f);
+            write!(out, "{}", line);
             out.new_line();
         }
         if let Some(f) = self.config.include_guard() {
@@ -379,7 +379,7 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
         if self.config.no_includes
             && self.config.sys_includes().is_empty()
             && self.config.includes().is_empty()
-            && self.config.after_includes.is_none()
+            && self.config.after_includes.is_empty()
         {
             return;
         }
@@ -439,7 +439,7 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
             out.new_line();
         }
 
-        if let Some(ref line) = self.config.after_includes {
+        for line in self.config.after_includes.text_for(self.config.language) {
             write!(out, "{}", line);
             out.new_line();
         }

--- a/src/bindgen/language_backend/cython.rs
+++ b/src/bindgen/language_backend/cython.rs
@@ -47,9 +47,9 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
             write!(out, "''' Package version: {} '''", package_version);
             out.new_line();
         }
-        if let Some(ref f) = self.config.header {
+        for line in self.config.header.text_for(self.config.language) {
             out.new_line_if_not_start();
-            write!(out, "{}", f);
+            write!(out, "{}", line);
             out.new_line();
         }
 
@@ -72,7 +72,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
             && self.config.sys_includes().is_empty()
             && self.config.includes().is_empty()
             && (self.config.cython.cimports.is_empty())
-            && self.config.after_includes.is_none()
+            && self.config.after_includes.is_empty()
         {
             return;
         }
@@ -98,7 +98,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
             out.new_line();
         }
 
-        if let Some(ref line) = &self.config.after_includes {
+        for line in self.config.after_includes.text_for(self.config.language) {
             write!(out, "{}", line);
             out.new_line();
         }

--- a/src/bindgen/language_backend/mod.rs
+++ b/src/bindgen/language_backend/mod.rs
@@ -199,10 +199,10 @@ pub trait LanguageBackend: Sized {
     }
 
     fn write_trailer<W: Write>(&mut self, out: &mut SourceWriter<W>, b: &Bindings) {
-        if let Some(ref f) = b.config.trailer {
+        for line in b.config.trailer.text_for(b.config.language) {
             out.new_line_if_not_start();
-            write!(out, "{}", f);
-            if !f.ends_with('\n') {
+            write!(out, "{}", line);
+            if !line.ends_with('\n') {
                 out.new_line();
             }
         }

--- a/tests/expectations/box.c
+++ b/tests/expectations/box.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/box.compat.c
+++ b/tests/expectations/box.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/box.cpp
+++ b/tests/expectations/box.cpp
@@ -1,15 +1,5 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
 template <typename T>
 using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
 
 
 #include <cstdarg>

--- a/tests/expectations/box.pyx
+++ b/tests/expectations/box.pyx
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/box_both.c
+++ b/tests/expectations/box_both.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/box_both.compat.c
+++ b/tests/expectations/box_both.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/box_tag.c
+++ b/tests/expectations/box_tag.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/box_tag.compat.c
+++ b/tests/expectations/box_tag.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/box_tag.pyx
+++ b/tests/expectations/box_tag.pyx
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/enum.c
+++ b/tests/expectations/enum.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -245,17 +231,9 @@ void root(Opaque *opaque,
           Q q,
           R r);
 
-#if 0
-''' '
-#endif
-
 #include <stddef.h>
 #include "testing-helpers.h"
 static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
-
-#if 0
-' '''
-#endif

--- a/tests/expectations/enum.compat.c
+++ b/tests/expectations/enum.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -319,17 +305,9 @@ void root(Opaque *opaque,
 }  // extern "C"
 #endif  // __cplusplus
 
-#if 0
-''' '
-#endif
-
 #include <stddef.h>
 #include "testing-helpers.h"
 static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
-
-#if 0
-' '''
-#endif

--- a/tests/expectations/enum.cpp
+++ b/tests/expectations/enum.cpp
@@ -1,15 +1,5 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
 template <typename T>
 using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
 
 
 #include <cstdarg>
@@ -255,17 +245,9 @@ void root(Opaque *opaque,
 
 }  // extern "C"
 
-#if 0
-''' '
-#endif
-
 #include <stddef.h>
 #include "testing-helpers.h"
 static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
-
-#if 0
-' '''
-#endif

--- a/tests/expectations/enum.pyx
+++ b/tests/expectations/enum.pyx
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:
@@ -199,9 +185,7 @@ cdef extern from *:
             Q q,
             R r);
 
-#if 0
 ''' '
-#endif
 
 #include <stddef.h>
 #include "testing-helpers.h"
@@ -210,6 +194,4 @@ static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0")
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
 
-#if 0
 ' '''
-#endif

--- a/tests/expectations/enum_both.c
+++ b/tests/expectations/enum_both.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -245,17 +231,9 @@ void root(struct Opaque *opaque,
           struct Q q,
           struct R r);
 
-#if 0
-''' '
-#endif
-
 #include <stddef.h>
 #include "testing-helpers.h"
 static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
-
-#if 0
-' '''
-#endif

--- a/tests/expectations/enum_both.compat.c
+++ b/tests/expectations/enum_both.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -319,17 +305,9 @@ void root(struct Opaque *opaque,
 }  // extern "C"
 #endif  // __cplusplus
 
-#if 0
-''' '
-#endif
-
 #include <stddef.h>
 #include "testing-helpers.h"
 static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
-
-#if 0
-' '''
-#endif

--- a/tests/expectations/enum_tag.c
+++ b/tests/expectations/enum_tag.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -245,17 +231,9 @@ void root(struct Opaque *opaque,
           struct Q q,
           struct R r);
 
-#if 0
-''' '
-#endif
-
 #include <stddef.h>
 #include "testing-helpers.h"
 static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
-
-#if 0
-' '''
-#endif

--- a/tests/expectations/enum_tag.compat.c
+++ b/tests/expectations/enum_tag.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -319,17 +305,9 @@ void root(struct Opaque *opaque,
 }  // extern "C"
 #endif  // __cplusplus
 
-#if 0
-''' '
-#endif
-
 #include <stddef.h>
 #include "testing-helpers.h"
 static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
-
-#if 0
-' '''
-#endif

--- a/tests/expectations/enum_tag.pyx
+++ b/tests/expectations/enum_tag.pyx
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:
@@ -199,9 +185,7 @@ cdef extern from *:
             Q q,
             R r);
 
-#if 0
 ''' '
-#endif
 
 #include <stddef.h>
 #include "testing-helpers.h"
@@ -210,6 +194,4 @@ static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0")
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
 
-#if 0
 ' '''
-#endif

--- a/tests/expectations/exclude_generic_monomorph.c
+++ b/tests/expectations/exclude_generic_monomorph.c
@@ -1,19 +1,6 @@
 #include <stdint.h>
 
-#if 0
-''' '
-#endif
-
 typedef uint64_t Option_Foo;
-
-#if 0
-' '''
-#endif
-
-#if 0
-from libc.stdint cimport uint64_t
-ctypedef uint64_t Option_Foo
-#endif
 
 
 #include <stdarg.h>

--- a/tests/expectations/exclude_generic_monomorph.compat.c
+++ b/tests/expectations/exclude_generic_monomorph.compat.c
@@ -1,19 +1,6 @@
 #include <stdint.h>
 
-#if 0
-''' '
-#endif
-
 typedef uint64_t Option_Foo;
-
-#if 0
-' '''
-#endif
-
-#if 0
-from libc.stdint cimport uint64_t
-ctypedef uint64_t Option_Foo
-#endif
 
 
 #include <stdarg.h>

--- a/tests/expectations/exclude_generic_monomorph.cpp
+++ b/tests/expectations/exclude_generic_monomorph.cpp
@@ -1,19 +1,6 @@
 #include <stdint.h>
 
-#if 0
-''' '
-#endif
-
 typedef uint64_t Option_Foo;
-
-#if 0
-' '''
-#endif
-
-#if 0
-from libc.stdint cimport uint64_t
-ctypedef uint64_t Option_Foo
-#endif
 
 
 #include <stdarg.h>

--- a/tests/expectations/exclude_generic_monomorph.pyx
+++ b/tests/expectations/exclude_generic_monomorph.pyx
@@ -1,19 +1,13 @@
-#include <stdint.h>
-
-#if 0
 ''' '
-#endif
+
+#include <stdint.h>
 
 typedef uint64_t Option_Foo;
 
-#if 0
-' '''
-#endif
 
-#if 0
+' '''
 from libc.stdint cimport uint64_t
 ctypedef uint64_t Option_Foo
-#endif
 
 
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t

--- a/tests/expectations/exclude_generic_monomorph_both.c
+++ b/tests/expectations/exclude_generic_monomorph_both.c
@@ -1,19 +1,6 @@
 #include <stdint.h>
 
-#if 0
-''' '
-#endif
-
 typedef uint64_t Option_Foo;
-
-#if 0
-' '''
-#endif
-
-#if 0
-from libc.stdint cimport uint64_t
-ctypedef uint64_t Option_Foo
-#endif
 
 
 #include <stdarg.h>

--- a/tests/expectations/exclude_generic_monomorph_both.compat.c
+++ b/tests/expectations/exclude_generic_monomorph_both.compat.c
@@ -1,19 +1,6 @@
 #include <stdint.h>
 
-#if 0
-''' '
-#endif
-
 typedef uint64_t Option_Foo;
-
-#if 0
-' '''
-#endif
-
-#if 0
-from libc.stdint cimport uint64_t
-ctypedef uint64_t Option_Foo
-#endif
 
 
 #include <stdarg.h>

--- a/tests/expectations/exclude_generic_monomorph_tag.c
+++ b/tests/expectations/exclude_generic_monomorph_tag.c
@@ -1,19 +1,6 @@
 #include <stdint.h>
 
-#if 0
-''' '
-#endif
-
 typedef uint64_t Option_Foo;
-
-#if 0
-' '''
-#endif
-
-#if 0
-from libc.stdint cimport uint64_t
-ctypedef uint64_t Option_Foo
-#endif
 
 
 #include <stdarg.h>

--- a/tests/expectations/exclude_generic_monomorph_tag.compat.c
+++ b/tests/expectations/exclude_generic_monomorph_tag.compat.c
@@ -1,19 +1,6 @@
 #include <stdint.h>
 
-#if 0
-''' '
-#endif
-
 typedef uint64_t Option_Foo;
-
-#if 0
-' '''
-#endif
-
-#if 0
-from libc.stdint cimport uint64_t
-ctypedef uint64_t Option_Foo
-#endif
 
 
 #include <stdarg.h>

--- a/tests/expectations/exclude_generic_monomorph_tag.pyx
+++ b/tests/expectations/exclude_generic_monomorph_tag.pyx
@@ -1,19 +1,13 @@
-#include <stdint.h>
-
-#if 0
 ''' '
-#endif
+
+#include <stdint.h>
 
 typedef uint64_t Option_Foo;
 
-#if 0
-' '''
-#endif
 
-#if 0
+' '''
 from libc.stdint cimport uint64_t
 ctypedef uint64_t Option_Foo
-#endif
 
 
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t

--- a/tests/expectations/forward_declaration.c
+++ b/tests/expectations/forward_declaration.c
@@ -1,11 +1,5 @@
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
-#endif
-#if 0
-' '''
 #endif
 
 
@@ -39,12 +33,6 @@ typedef struct {
 
 void root(TypeInfo x);
 
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 */
-#endif
-#if 0
-' '''
 #endif

--- a/tests/expectations/forward_declaration.compat.c
+++ b/tests/expectations/forward_declaration.compat.c
@@ -1,11 +1,5 @@
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
-#endif
-#if 0
-' '''
 #endif
 
 
@@ -47,12 +41,6 @@ void root(TypeInfo x);
 }  // extern "C"
 #endif  // __cplusplus
 
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 */
-#endif
-#if 0
-' '''
 #endif

--- a/tests/expectations/forward_declaration.cpp
+++ b/tests/expectations/forward_declaration.cpp
@@ -1,11 +1,5 @@
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
-#endif
-#if 0
-' '''
 #endif
 
 
@@ -46,12 +40,6 @@ void root(TypeInfo x);
 
 }  // extern "C"
 
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 */
-#endif
-#if 0
-' '''
 #endif

--- a/tests/expectations/forward_declaration.pyx
+++ b/tests/expectations/forward_declaration.pyx
@@ -1,13 +1,11 @@
-#if 0
 ''' '
-#endif
+
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
 #endif
-#if 0
-' '''
-#endif
 
+
+' '''
 
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
@@ -34,12 +32,10 @@ cdef extern from *:
 
   void root(TypeInfo x);
 
-#if 0
 ''' '
-#endif
+
 #if defined(CBINDGEN_STYLE_TYPE)
 */
 #endif
-#if 0
+
 ' '''
-#endif

--- a/tests/expectations/forward_declaration_both.c
+++ b/tests/expectations/forward_declaration_both.c
@@ -1,11 +1,5 @@
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
-#endif
-#if 0
-' '''
 #endif
 
 
@@ -39,12 +33,6 @@ typedef struct TypeInfo {
 
 void root(struct TypeInfo x);
 
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 */
-#endif
-#if 0
-' '''
 #endif

--- a/tests/expectations/forward_declaration_both.compat.c
+++ b/tests/expectations/forward_declaration_both.compat.c
@@ -1,11 +1,5 @@
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
-#endif
-#if 0
-' '''
 #endif
 
 
@@ -47,12 +41,6 @@ void root(struct TypeInfo x);
 }  // extern "C"
 #endif  // __cplusplus
 
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 */
-#endif
-#if 0
-' '''
 #endif

--- a/tests/expectations/forward_declaration_tag.c
+++ b/tests/expectations/forward_declaration_tag.c
@@ -1,11 +1,5 @@
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
-#endif
-#if 0
-' '''
 #endif
 
 
@@ -39,12 +33,6 @@ struct TypeInfo {
 
 void root(struct TypeInfo x);
 
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 */
-#endif
-#if 0
-' '''
 #endif

--- a/tests/expectations/forward_declaration_tag.compat.c
+++ b/tests/expectations/forward_declaration_tag.compat.c
@@ -1,11 +1,5 @@
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
-#endif
-#if 0
-' '''
 #endif
 
 
@@ -47,12 +41,6 @@ void root(struct TypeInfo x);
 }  // extern "C"
 #endif  // __cplusplus
 
-#if 0
-''' '
-#endif
 #if defined(CBINDGEN_STYLE_TYPE)
 */
-#endif
-#if 0
-' '''
 #endif

--- a/tests/expectations/forward_declaration_tag.pyx
+++ b/tests/expectations/forward_declaration_tag.pyx
@@ -1,13 +1,11 @@
-#if 0
 ''' '
-#endif
+
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
 #endif
-#if 0
-' '''
-#endif
 
+
+' '''
 
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
@@ -34,12 +32,10 @@ cdef extern from *:
 
   void root(TypeInfo x);
 
-#if 0
 ''' '
-#endif
+
 #if defined(CBINDGEN_STYLE_TYPE)
 */
 #endif
-#if 0
+
 ' '''
-#endif

--- a/tests/expectations/manuallydrop.c
+++ b/tests/expectations/manuallydrop.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using ManuallyDrop = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/manuallydrop.compat.c
+++ b/tests/expectations/manuallydrop.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using ManuallyDrop = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/manuallydrop.cpp
+++ b/tests/expectations/manuallydrop.cpp
@@ -1,15 +1,5 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
 template <typename T>
 using ManuallyDrop = T;
-#endif
-
-#if 0
-' '''
-#endif
 
 
 #include <cstdarg>

--- a/tests/expectations/manuallydrop.pyx
+++ b/tests/expectations/manuallydrop.pyx
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using ManuallyDrop = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/manuallydrop_both.c
+++ b/tests/expectations/manuallydrop_both.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using ManuallyDrop = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/manuallydrop_both.compat.c
+++ b/tests/expectations/manuallydrop_both.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using ManuallyDrop = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/manuallydrop_tag.c
+++ b/tests/expectations/manuallydrop_tag.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using ManuallyDrop = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/manuallydrop_tag.compat.c
+++ b/tests/expectations/manuallydrop_tag.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using ManuallyDrop = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/manuallydrop_tag.pyx
+++ b/tests/expectations/manuallydrop_tag.pyx
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using ManuallyDrop = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/maybeuninit.c
+++ b/tests/expectations/maybeuninit.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using MaybeUninit = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/maybeuninit.compat.c
+++ b/tests/expectations/maybeuninit.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using MaybeUninit = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/maybeuninit.cpp
+++ b/tests/expectations/maybeuninit.cpp
@@ -1,15 +1,5 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
 template <typename T>
 using MaybeUninit = T;
-#endif
-
-#if 0
-' '''
-#endif
 
 
 #include <cstdarg>

--- a/tests/expectations/maybeuninit.pyx
+++ b/tests/expectations/maybeuninit.pyx
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using MaybeUninit = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/maybeuninit_both.c
+++ b/tests/expectations/maybeuninit_both.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using MaybeUninit = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/maybeuninit_both.compat.c
+++ b/tests/expectations/maybeuninit_both.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using MaybeUninit = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/maybeuninit_tag.c
+++ b/tests/expectations/maybeuninit_tag.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using MaybeUninit = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/maybeuninit_tag.compat.c
+++ b/tests/expectations/maybeuninit_tag.compat.c
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using MaybeUninit = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/maybeuninit_tag.pyx
+++ b/tests/expectations/maybeuninit_tag.pyx
@@ -1,17 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using MaybeUninit = T;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/nonzero.c
+++ b/tests/expectations/nonzero.c
@@ -1,16 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/nonzero.compat.c
+++ b/tests/expectations/nonzero.compat.c
@@ -1,16 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/nonzero.cpp
+++ b/tests/expectations/nonzero.cpp
@@ -1,14 +1,4 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
 struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
 
 
 #include <cstdarg>

--- a/tests/expectations/nonzero.pyx
+++ b/tests/expectations/nonzero.pyx
@@ -1,16 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/nonzero_both.c
+++ b/tests/expectations/nonzero_both.c
@@ -1,16 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/nonzero_both.compat.c
+++ b/tests/expectations/nonzero_both.compat.c
@@ -1,16 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/nonzero_tag.c
+++ b/tests/expectations/nonzero_tag.c
@@ -1,16 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/nonzero_tag.compat.c
+++ b/tests/expectations/nonzero_tag.compat.c
@@ -1,16 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/nonzero_tag.pyx
+++ b/tests/expectations/nonzero_tag.pyx
@@ -1,16 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/opaque.c
+++ b/tests/expectations/opaque.c
@@ -1,20 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-// These could be added as opaque types I guess.
-template <typename T>
-struct BuildHasherDefault;
-
-struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/opaque.compat.c
+++ b/tests/expectations/opaque.compat.c
@@ -1,20 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-// These could be added as opaque types I guess.
-template <typename T>
-struct BuildHasherDefault;
-
-struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/opaque.cpp
+++ b/tests/expectations/opaque.cpp
@@ -1,18 +1,8 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
 // These could be added as opaque types I guess.
 template <typename T>
 struct BuildHasherDefault;
 
 struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
 
 
 #include <cstdarg>

--- a/tests/expectations/opaque.pyx
+++ b/tests/expectations/opaque.pyx
@@ -1,20 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-// These could be added as opaque types I guess.
-template <typename T>
-struct BuildHasherDefault;
-
-struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/opaque_both.c
+++ b/tests/expectations/opaque_both.c
@@ -1,20 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-// These could be added as opaque types I guess.
-template <typename T>
-struct BuildHasherDefault;
-
-struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/opaque_both.compat.c
+++ b/tests/expectations/opaque_both.compat.c
@@ -1,20 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-// These could be added as opaque types I guess.
-template <typename T>
-struct BuildHasherDefault;
-
-struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/opaque_tag.c
+++ b/tests/expectations/opaque_tag.c
@@ -1,20 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-// These could be added as opaque types I guess.
-template <typename T>
-struct BuildHasherDefault;
-
-struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/opaque_tag.compat.c
+++ b/tests/expectations/opaque_tag.compat.c
@@ -1,20 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-// These could be added as opaque types I guess.
-template <typename T>
-struct BuildHasherDefault;
-
-struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/opaque_tag.pyx
+++ b/tests/expectations/opaque_tag.pyx
@@ -1,20 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-// These could be added as opaque types I guess.
-template <typename T>
-struct BuildHasherDefault;
-
-struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/pin.c
+++ b/tests/expectations/pin.c
@@ -1,19 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Pin = T;
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/pin.compat.c
+++ b/tests/expectations/pin.compat.c
@@ -1,19 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Pin = T;
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/pin.cpp
+++ b/tests/expectations/pin.cpp
@@ -1,17 +1,7 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
 template <typename T>
 using Pin = T;
 template <typename T>
 using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
 
 
 #include <cstdarg>

--- a/tests/expectations/pin.pyx
+++ b/tests/expectations/pin.pyx
@@ -1,19 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Pin = T;
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/expectations/pin_both.c
+++ b/tests/expectations/pin_both.c
@@ -1,19 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Pin = T;
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/pin_both.compat.c
+++ b/tests/expectations/pin_both.compat.c
@@ -1,19 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Pin = T;
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/pin_tag.c
+++ b/tests/expectations/pin_tag.c
@@ -1,19 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Pin = T;
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/pin_tag.compat.c
+++ b/tests/expectations/pin_tag.compat.c
@@ -1,19 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Pin = T;
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/expectations/pin_tag.pyx
+++ b/tests/expectations/pin_tag.pyx
@@ -1,19 +1,3 @@
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
-template <typename T>
-using Pin = T;
-template <typename T>
-using Box = T*;
-#endif
-
-#if 0
-' '''
-#endif
-
-
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 cdef extern from *:

--- a/tests/rust/box.toml
+++ b/tests/rust/box.toml
@@ -1,17 +1,8 @@
-header = """
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
+header = { language = "C++", line = """
 template <typename T>
 using Box = T*;
-#endif
+""" }
 
-#if 0
-' '''
-#endif
-"""
 [export]
 exclude = [
   "Box",

--- a/tests/rust/enum.toml
+++ b/tests/rust/enum.toml
@@ -1,34 +1,20 @@
-header = """
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
+header = { language = "C++", line = """
 template <typename T>
 using Box = T*;
-#endif
+""" }
 
-#if 0
-' '''
-#endif
-"""
-
-trailer = """
-#if 0
-''' '
-#endif
-
+trailer = [
+    { language = "Cython", line = "''' '" },
+    """
 #include <stddef.h>
 #include "testing-helpers.h"
 static_assert(offsetof(CBINDGEN_STRUCT(P), tag) == 0, "unexpected offset for tag");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p0");
 static_assert(offsetof(CBINDGEN_STRUCT(P), p0) == 1, "unexpected offset for p1");
 static_assert(sizeof(CBINDGEN_STRUCT(P)) == 4, "unexpected size for P");
-
-#if 0
-' '''
-#endif
-"""
+""",
+    { language = "Cython", line = "' '''" },
+]
 
 [export]
 exclude = [

--- a/tests/rust/exclude_generic_monomorph.toml
+++ b/tests/rust/exclude_generic_monomorph.toml
@@ -1,22 +1,17 @@
 language = "C"
-header = """
+header = [
+    { language = "Cython", line = "''' '" },
+    """
 #include <stdint.h>
 
-#if 0
-''' '
-#endif
-
 typedef uint64_t Option_Foo;
-
-#if 0
+""",
+    { language = "Cython", line = """
 ' '''
-#endif
-
-#if 0
 from libc.stdint cimport uint64_t
 ctypedef uint64_t Option_Foo
-#endif
-"""
+""" },
+]
 
 [export]
 exclude = [

--- a/tests/rust/forward_declaration.toml
+++ b/tests/rust/forward_declaration.toml
@@ -1,23 +1,19 @@
-header = """
-#if 0
-''' '
-#endif
+header = [
+    { language = "Cython", line = "''' '" },
+    """
 #if defined(CBINDGEN_STYLE_TYPE)
 /* ANONYMOUS STRUCTS DO NOT SUPPORT FORWARD DECLARATIONS!
 #endif
-#if 0
-' '''
-#endif
-"""
+""",
+    { language = "Cython", line = "' '''" },
+]
 
-trailer = """
-#if 0
-''' '
-#endif
+trailer = [
+    { language = "Cython", line = "''' '" },
+    """
 #if defined(CBINDGEN_STYLE_TYPE)
 */
 #endif
-#if 0
-' '''
-#endif
-"""
+""",
+    { language = "Cython", line = "' '''" },
+]

--- a/tests/rust/manuallydrop.toml
+++ b/tests/rust/manuallydrop.toml
@@ -1,17 +1,8 @@
-header = """
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
+header = { language = "C++", line = """
 template <typename T>
 using ManuallyDrop = T;
-#endif
+""" }
 
-#if 0
-' '''
-#endif
-"""
 [export]
 exclude = [
   "ManuallyDrop",

--- a/tests/rust/maybeuninit.toml
+++ b/tests/rust/maybeuninit.toml
@@ -1,17 +1,8 @@
-header = """
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
+header = { language = "C++", line = """
 template <typename T>
 using MaybeUninit = T;
-#endif
+""" }
 
-#if 0
-' '''
-#endif
-"""
 [export]
 exclude = [
   "MaybeUninit",

--- a/tests/rust/nonzero.toml
+++ b/tests/rust/nonzero.toml
@@ -1,13 +1,3 @@
-header = """
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
+header = { language = "C++", line = """
 struct NonZeroI64;
-#endif
-
-#if 0
-' '''
-#endif
-"""
+""" }

--- a/tests/rust/opaque.toml
+++ b/tests/rust/opaque.toml
@@ -1,17 +1,7 @@
-header = """
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
+header = { language = "C++", line = """
 // These could be added as opaque types I guess.
 template <typename T>
 struct BuildHasherDefault;
 
 struct DefaultHasher;
-#endif
-
-#if 0
-' '''
-#endif
-"""
+""" }

--- a/tests/rust/pin.toml
+++ b/tests/rust/pin.toml
@@ -1,19 +1,10 @@
-header = """
-#if 0
-''' '
-#endif
-
-#ifdef __cplusplus
+header = { language = "C++", line = """
 template <typename T>
 using Pin = T;
 template <typename T>
 using Box = T*;
-#endif
+""" }
 
-#if 0
-' '''
-#endif
-"""
 [export]
 exclude = [
     "Pin",


### PR DESCRIPTION
### Motivation:
Some cbindgen tests have a toml config file.
That config file must work with multiple languages.
Hard to understand tricks are used, making it harder for cbindgen contributors to make tests for their code.
A better solution is to allow language-specific text in text fields that allow "code".

### Changes:
This PR attempts to do that, while maintaining backwards compatibility.
I chose a serde-compatible way to represent the data (untagged enums) but can change to whatever you want.

Only **header**, **trailer**, **after_includes** were changed.
Other fields that output raw "code" can be changed too.
No idea how docs.md should be changed so I left it alone.

### Fields:
Text field can be a line field or a sequence of lines or structs:
```toml
field = [
   "sequence of lines",
   { language = "C", line = "or structs" },
]
```

Line field can be a single line `field = "line"` or a struct `field = { language = "C", line = "struct" }`.
