### PR TITLE
Implement whitelist in ExportConfig

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -596,6 +596,11 @@ include = ["MyOrphanStruct", "MyGreatTypeRename"]
 # default: []
 exclude = ["Bad"]
 
+# A list of items to include in the generated bindings, while excluding other unlisted
+# items from being exported. Has lower precedence than `include` and `exclude`, so they
+# can still add or remove items regardless of the whitelist's value.
+whitelist = ["MyImportantStruct", "Bad"]
+
 # A prefix to add before the name of every item
 # default: no prefix is added
 prefix = "CAPI_"

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -327,6 +327,11 @@ pub struct ExportConfig {
     pub include: Vec<String>,
     /// A list of items to not include in the generated bindings
     pub exclude: Vec<String>,
+    /// A list of whitelisted items. When non-empty, only items included in the
+    /// whitelist will be included in the generated bindings. `include` and
+    /// `exclude` have priority over this, and will add or remove items to/from
+    /// the generated bindings regardless of their inclusion in the whitelist.
+    pub whitelist: Vec<String>,
     /// Table of name conversions to apply to item names
     pub rename: HashMap<String, String>,
     /// Table of raw strings to prepend to the body of items.


### PR DESCRIPTION
Adds a field `whitelist` to `ExportConfig`, allowing users to specify an exclusive list of items they wish to include in the generated header file. If the field is left empty it is ignored. 

If excludes or includes are specified, they override the whitelist. For example in the case where we have functions `foo`, `bar`, and `baz` and our whitelist specifies `foo` and `bar`, then only `foo` and `bar` will be included in the output header file. If they add an include `baz`, all three functions will be included in the output. If they then add an exclude `foo`, only `bar` and `baz` will be included in the output.