### PR TITLE
Bump MSRV

### DIFF
--- a/.github/workflows/cbindgen.yml
+++ b/.github/workflows/cbindgen.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Install minimum supported Rust version
       id: msrv
-      uses: dtolnay/rust-toolchain@1.70
+      uses: dtolnay/rust-toolchain@1.74
 
     - name: Build with minimum supported Rust version
       run: |

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@
 
       * Revert: The `Config` struct now has a private member.
       * Allow users to specify a crate version for bindings generation (#901).
-      * Update MSRV to 1.70 (#912).
+      * Update MSRV to 1.74 (#912, #987).
       * Support #[deprecated] on enum variants (#933).
       * Support integrating the package_version information in a header file comment (#939).
       * Add a language backend (#942).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["bindings", "ffi", "code-generation"]
 categories = ["external-ffi-bindings", "development-tools::ffi"]
 repository = "https://github.com/mozilla/cbindgen"
 edition = "2018"
-rust-version = "1.70"
+rust-version = "1.74"
 exclude = [
   "tests/profile.rs", # Test relies in a sub-crate, see https://github.com/rust-lang/cargo/issues/9017
 ]


### PR DESCRIPTION
It seems the merge queue is not waiting properly for the jobs to finish, so #986 got through without the MSRV check passing.

For now, bump the MSRV, I'll fix the merge queue separately.