### PR TITLE
Deduplicate the code that turns transparent structs into typedefs

### DIFF
--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -129,9 +129,8 @@ impl Struct {
     ) -> Self {
         // WARNING: Zero-sized transparent structs are legal rust [1], but zero-sized types of any
         // repr are "best avoided entirely" [2] because they "will be nonsensical or problematic if
-        // passed through the FFI boundary" [3]. Further, because there no well-defined underlying
-        // native type exists for a ZST, we cannot emit a typedef for it and must treat it as an
-        // empty repr(C) struct instead.
+        // passed through the FFI boundary" [3]. Further, because no well-defined underlying native
+        // type exists for a ZST, we cannot emit a typedef and must define an empty struct instead.
         //
         // [1] https://github.com/rust-lang/rust/issues/77841#issuecomment-716575747
         // [2] https://github.com/rust-lang/rust/issues/77841#issuecomment-716796313

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -127,9 +127,9 @@ impl Struct {
         annotations: AnnotationSet,
         documentation: Documentation,
     ) -> Self {
-        // WARNING: The rust compiler rejects a `#[repr(transparent)]` struct with 2+ NZST fields, but
-        // accepts an empty struct (see https://github.com/rust-lang/rust/issues/129029). We must
-        // not emit a typedef in that case, because there is no underlying type.
+        // https://github.com/rust-lang/rust/issues/129029: The rust compiler accepts an empty
+        // `#[repr(transparent)]` struct. We must not emit a typedef in that case, because there is
+        // no underlying type it could refer to.
         if is_transparent && fields.len() != 1 {
             error!("Illegal empty transparent struct {}", &path);
             is_transparent = false;

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -10,8 +10,8 @@ use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, GenericArgument, GenericParams, Item, ItemContainer, Path,
-    Type,
+    AnnotationSet, Cfg, Documentation, Field, GenericArgument, GenericParams, Item, ItemContainer,
+    Path, Struct, Type,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -68,6 +68,19 @@ impl Typedef {
 
     pub fn simplify_standard_types(&mut self, config: &Config) {
         self.aliased.simplify_standard_types(config);
+    }
+
+    // Used to convert a transparent Struct to a Typedef.
+    pub fn new_from_struct_field(item: &Struct, field: &Field) -> Self {
+        Self {
+            path: item.path().clone(),
+            export_name: item.export_name().to_string(),
+            generic_params: item.generic_params.clone(),
+            aliased: field.ty.clone(),
+            cfg: item.cfg().cloned(),
+            annotations: item.annotations().clone(),
+            documentation: item.documentation().clone(),
+        }
     }
 
     pub fn transfer_annotations(&mut self, out: &mut HashMap<Path, AnnotationSet>) {

--- a/src/bindgen/language_backend/clike.rs
+++ b/src/bindgen/language_backend/clike.rs
@@ -540,24 +540,6 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
     }
 
     fn write_struct<W: Write>(&mut self, out: &mut SourceWriter<W>, s: &Struct) {
-        if s.is_transparent {
-            let typedef = Typedef {
-                path: s.path.clone(),
-                export_name: s.export_name.to_owned(),
-                generic_params: s.generic_params.clone(),
-                aliased: s.fields[0].ty.clone(),
-                cfg: s.cfg.clone(),
-                annotations: s.annotations.clone(),
-                documentation: s.documentation.clone(),
-            };
-            self.write_type_def(out, &typedef);
-            for constant in &s.associated_constants {
-                out.new_line();
-                constant.write(self.config, self, out, Some(s));
-            }
-            return;
-        }
-
         let condition = s.cfg.to_condition(self.config);
         condition.write_before(self.config, out);
 

--- a/src/bindgen/language_backend/cython.rs
+++ b/src/bindgen/language_backend/cython.rs
@@ -159,24 +159,6 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
     }
 
     fn write_struct<W: Write>(&mut self, out: &mut SourceWriter<W>, s: &Struct) {
-        if s.is_transparent {
-            let typedef = Typedef {
-                path: s.path.clone(),
-                export_name: s.export_name.to_owned(),
-                generic_params: s.generic_params.clone(),
-                aliased: s.fields[0].ty.clone(),
-                cfg: s.cfg.clone(),
-                annotations: s.annotations.clone(),
-                documentation: s.documentation.clone(),
-            };
-            self.write_type_def(out, &typedef);
-            for constant in &s.associated_constants {
-                out.new_line();
-                constant.write(self.config, self, out, Some(s));
-            }
-            return;
-        }
-
         let condition = s.cfg.to_condition(self.config);
         condition.write_before(self.config, out);
 

--- a/tests/expectations/transparent.c
+++ b/tests/expectations/transparent.c
@@ -23,6 +23,10 @@ typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 #define TransparentPrimitiveWithAssociatedConstants_ZERO 0
 #define TransparentPrimitiveWithAssociatedConstants_ONE 1
 
+typedef struct {
+
+} TransparentEmptyStructure;
+
 #define EnumWithAssociatedConstantInImpl_TEN 10
 
 void root(TransparentComplexWrappingStructTuple a,
@@ -32,4 +36,5 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentComplexWrapper_i32 e,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
-          EnumWithAssociatedConstantInImpl h);
+          TransparentEmptyStructure h,
+          EnumWithAssociatedConstantInImpl i);

--- a/tests/expectations/transparent.compat.c
+++ b/tests/expectations/transparent.compat.c
@@ -23,6 +23,10 @@ typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 #define TransparentPrimitiveWithAssociatedConstants_ZERO 0
 #define TransparentPrimitiveWithAssociatedConstants_ONE 1
 
+typedef struct {
+
+} TransparentEmptyStructure;
+
 #define EnumWithAssociatedConstantInImpl_TEN 10
 
 #ifdef __cplusplus
@@ -36,7 +40,8 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentComplexWrapper_i32 e,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
-          EnumWithAssociatedConstantInImpl h);
+          TransparentEmptyStructure h,
+          EnumWithAssociatedConstantInImpl i);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/transparent.cpp
+++ b/tests/expectations/transparent.cpp
@@ -26,6 +26,10 @@ using TransparentPrimitiveWithAssociatedConstants = uint32_t;
 constexpr static const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ZERO = 0;
 constexpr static const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ONE = 1;
 
+struct TransparentEmptyStructure {
+
+};
+
 constexpr static const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_TEN = 10;
 
 extern "C" {
@@ -37,6 +41,7 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentComplexWrapper<int32_t> e,
           TransparentPrimitiveWrapper<int32_t> f,
           TransparentPrimitiveWithAssociatedConstants g,
-          EnumWithAssociatedConstantInImpl h);
+          TransparentEmptyStructure h,
+          EnumWithAssociatedConstantInImpl i);
 
 }  // extern "C"

--- a/tests/expectations/transparent.pyx
+++ b/tests/expectations/transparent.pyx
@@ -28,6 +28,9 @@ cdef extern from *:
   const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ZERO # = 0
   const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ONE # = 1
 
+  ctypedef struct TransparentEmptyStructure:
+    pass
+
   const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_TEN # = 10
 
   void root(TransparentComplexWrappingStructTuple a,
@@ -37,4 +40,5 @@ cdef extern from *:
             TransparentComplexWrapper_i32 e,
             TransparentPrimitiveWrapper_i32 f,
             TransparentPrimitiveWithAssociatedConstants g,
-            EnumWithAssociatedConstantInImpl h);
+            TransparentEmptyStructure h,
+            EnumWithAssociatedConstantInImpl i);

--- a/tests/expectations/transparent_both.c
+++ b/tests/expectations/transparent_both.c
@@ -23,6 +23,10 @@ typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 #define TransparentPrimitiveWithAssociatedConstants_ZERO 0
 #define TransparentPrimitiveWithAssociatedConstants_ONE 1
 
+typedef struct TransparentEmptyStructure {
+
+} TransparentEmptyStructure;
+
 #define EnumWithAssociatedConstantInImpl_TEN 10
 
 void root(TransparentComplexWrappingStructTuple a,
@@ -32,4 +36,5 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentComplexWrapper_i32 e,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
-          struct EnumWithAssociatedConstantInImpl h);
+          struct TransparentEmptyStructure h,
+          struct EnumWithAssociatedConstantInImpl i);

--- a/tests/expectations/transparent_both.compat.c
+++ b/tests/expectations/transparent_both.compat.c
@@ -23,6 +23,10 @@ typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 #define TransparentPrimitiveWithAssociatedConstants_ZERO 0
 #define TransparentPrimitiveWithAssociatedConstants_ONE 1
 
+typedef struct TransparentEmptyStructure {
+
+} TransparentEmptyStructure;
+
 #define EnumWithAssociatedConstantInImpl_TEN 10
 
 #ifdef __cplusplus
@@ -36,7 +40,8 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentComplexWrapper_i32 e,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
-          struct EnumWithAssociatedConstantInImpl h);
+          struct TransparentEmptyStructure h,
+          struct EnumWithAssociatedConstantInImpl i);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/transparent_tag.c
+++ b/tests/expectations/transparent_tag.c
@@ -23,6 +23,10 @@ typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 #define TransparentPrimitiveWithAssociatedConstants_ZERO 0
 #define TransparentPrimitiveWithAssociatedConstants_ONE 1
 
+struct TransparentEmptyStructure {
+
+};
+
 #define EnumWithAssociatedConstantInImpl_TEN 10
 
 void root(TransparentComplexWrappingStructTuple a,
@@ -32,4 +36,5 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentComplexWrapper_i32 e,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
-          struct EnumWithAssociatedConstantInImpl h);
+          struct TransparentEmptyStructure h,
+          struct EnumWithAssociatedConstantInImpl i);

--- a/tests/expectations/transparent_tag.compat.c
+++ b/tests/expectations/transparent_tag.compat.c
@@ -23,6 +23,10 @@ typedef uint32_t TransparentPrimitiveWithAssociatedConstants;
 #define TransparentPrimitiveWithAssociatedConstants_ZERO 0
 #define TransparentPrimitiveWithAssociatedConstants_ONE 1
 
+struct TransparentEmptyStructure {
+
+};
+
 #define EnumWithAssociatedConstantInImpl_TEN 10
 
 #ifdef __cplusplus
@@ -36,7 +40,8 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentComplexWrapper_i32 e,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
-          struct EnumWithAssociatedConstantInImpl h);
+          struct TransparentEmptyStructure h,
+          struct EnumWithAssociatedConstantInImpl i);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/transparent_tag.pyx
+++ b/tests/expectations/transparent_tag.pyx
@@ -28,6 +28,9 @@ cdef extern from *:
   const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ZERO # = 0
   const TransparentPrimitiveWithAssociatedConstants TransparentPrimitiveWithAssociatedConstants_ONE # = 1
 
+  cdef struct TransparentEmptyStructure:
+    pass
+
   const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_TEN # = 10
 
   void root(TransparentComplexWrappingStructTuple a,
@@ -37,4 +40,5 @@ cdef extern from *:
             TransparentComplexWrapper_i32 e,
             TransparentPrimitiveWrapper_i32 f,
             TransparentPrimitiveWithAssociatedConstants g,
-            EnumWithAssociatedConstantInImpl h);
+            TransparentEmptyStructure h,
+            EnumWithAssociatedConstantInImpl i);

--- a/tests/rust/transparent.rs
+++ b/tests/rust/transparent.rs
@@ -41,6 +41,11 @@ impl TransparentPrimitiveWithAssociatedConstants {
 #[repr(transparent)]
 struct TransparentPrimitiveWithAssociatedConstants { bits: u32 }
 
+// https://github.com/rust-lang/rust/issues/129029 the rust compiler (wrongly?) accepts this, but
+// cbindgen should nevertheless emit the struct definition instead of a typedef.
+#[repr(transparent)]
+struct TransparentEmptyStructure;
+
 // Associated constant declared after struct declaration.
 impl TransparentPrimitiveWithAssociatedConstants {
     pub const ONE: TransparentPrimitiveWithAssociatedConstants = TransparentPrimitiveWithAssociatedConstants {
@@ -63,5 +68,6 @@ pub extern "C" fn root(
     e: TransparentComplexWrapper<i32>,
     f: TransparentPrimitiveWrapper<i32>,
     g: TransparentPrimitiveWithAssociatedConstants,
-    h: EnumWithAssociatedConstantInImpl,
+    h: TransparentEmptyStructure,
+    i: EnumWithAssociatedConstantInImpl,
 ) { }

--- a/tests/rust/transparent.rs
+++ b/tests/rust/transparent.rs
@@ -41,8 +41,8 @@ impl TransparentPrimitiveWithAssociatedConstants {
 #[repr(transparent)]
 struct TransparentPrimitiveWithAssociatedConstants { bits: u32 }
 
-// https://github.com/rust-lang/rust/issues/129029: The rust compiler (wrongly?) accepts a
-// transparent empty struct, but cbindgen should NOT emit a typedef in that case.
+// Transparent zero-sized structs are legal rust, but there's no way to emit a typedef for one, so
+// cbindgen should treat it as repr(C) instead and emit an empty struct definition.
 #[repr(transparent)]
 struct TransparentEmptyStructure;
 

--- a/tests/rust/transparent.rs
+++ b/tests/rust/transparent.rs
@@ -41,8 +41,8 @@ impl TransparentPrimitiveWithAssociatedConstants {
 #[repr(transparent)]
 struct TransparentPrimitiveWithAssociatedConstants { bits: u32 }
 
-// https://github.com/rust-lang/rust/issues/129029 the rust compiler (wrongly?) accepts this, but
-// cbindgen should nevertheless emit the struct definition instead of a typedef.
+// https://github.com/rust-lang/rust/issues/129029: The rust compiler (wrongly?) accepts a
+// transparent empty struct, but cbindgen should NOT emit a typedef in that case.
 #[repr(transparent)]
 struct TransparentEmptyStructure;
 


### PR DESCRIPTION
This is a "prefactor" for https://github.com/mozilla/cbindgen/pull/966, which centralizes the way cbindgen handles struct definitions that should be emitted as typedefs instead. For example, all backends emit `NonZero<T>` as a simple typedef, and the C backend emits `Option<T>` as a typedef as well. With this change, the code is generalized so that struct typedefs can be handled cleanly and centrally, instead of replicating code in each backend that needs it. It also opens a future path to handling transparent enums in the same way.

NOTE: With this change, cbindgen also handles zero-sized structs gracefully instead of crashing.