### PR TITLE
Default cpp_compat to true

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -501,8 +501,8 @@ no_includes = false
 #
 # If the language is not C this option won't have any effect.
 #
-# default: false
-cpp_compat = false
+# default: true
+cpp_compat = true
 
 # A list of lines to add verbatim after the includes block
 after_includes = "#define VERSION 1"

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -1051,7 +1051,7 @@ impl Default for Config {
             tab_width: 2,
             line_endings: LineEndingStyle::default(),
             language: Language::Cxx,
-            cpp_compat: false,
+            cpp_compat: true,
             style: Style::default(),
             usize_is_size_t: false,
             sort_by: SortKey::None,


### PR DESCRIPTION
I think there's no reason not to do this, since otherwise it's either extra work for maintainers of the Rust projects (by either creating separate C++ headers, or by creating a TOML file just to set this config), or for C++ users to wrap `extern "C"` around the `#include`.

This approach of ifdef'ing `__cplusplus` is used even in Lua, which is compatible with C89, so I think it's absolutely fine to generate this code, and I wouldn't expect any breakage.