### PR TITLE
Add rename-all=prefix:

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -154,7 +154,7 @@ impl EnumVariant {
 
         let body_rule = enum_annotations
             .parse_atom::<RenameRule>("rename-variant-name-fields")
-            .unwrap_or(config.enumeration.rename_variant_name_fields);
+            .unwrap_or(config.enumeration.rename_variant_name_fields.clone());
 
         let body = match variant.fields {
             syn::Fields::Unit => VariantBody::Empty(annotations),
@@ -556,7 +556,7 @@ impl Item for Enum {
         let rules = self
             .annotations
             .parse_atom::<RenameRule>("rename-all")
-            .unwrap_or(config.enumeration.rename_variants);
+            .unwrap_or(config.enumeration.rename_variants.clone());
 
         if let Some(r) = rules.not_none() {
             self.variants = self

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -159,7 +159,7 @@ impl Function {
         let rules = self
             .annotations
             .parse_atom::<RenameRule>("rename-all")
-            .unwrap_or(config.function.rename_args);
+            .unwrap_or(config.function.rename_args.clone());
 
         if let Some(r) = rules.not_none() {
             let args = std::mem::take(&mut self.args);

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -342,7 +342,7 @@ impl Item for Struct {
             let field_rules = self
                 .annotations
                 .parse_atom::<RenameRule>("rename-all")
-                .unwrap_or(config.structure.rename_fields);
+                .unwrap_or(config.structure.rename_fields.clone());
 
             if let Some(o) = self.annotations.list("field-names") {
                 for (dest, src) in names.zip(o) {

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -171,7 +171,7 @@ impl Item for Union {
         let rules = self
             .annotations
             .parse_atom::<RenameRule>("rename-all")
-            .unwrap_or(config.structure.rename_fields);
+            .unwrap_or(config.structure.rename_fields.clone());
 
         if let Some(o) = self.annotations.list("field-names") {
             let mut overriden_fields = Vec::new();

--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -93,6 +93,7 @@ impl<'a> Mangler<'a> {
                     &self
                         .config
                         .rename_types
+                        .clone()
                         .apply(&sub_path, IdentifierType::Type),
                 );
             }
@@ -101,6 +102,7 @@ impl<'a> Mangler<'a> {
                     &self
                         .config
                         .rename_types
+                        .clone()
                         .apply(primitive.to_repr_rust(), IdentifierType::Type),
                 );
             }


### PR DESCRIPTION
This adds a new rename-all annotation which allows setting a specific prefix to all fields. For example:

```rust
/// cbindgen:rename-all=prefix:ERR_
#[repr(i32)]
pub enum Error {
   BAD = 0,
   VERY_BAD = 1
}
```

While in principle this can be added to the config file, it's primarily useful for overrides on a case-by-case basis.