### PR TITLE
Implement mangling for arrays

### DIFF
--- a/src/bindgen/mangle.rs
+++ b/src/bindgen/mangle.rs
@@ -27,6 +27,8 @@ enum Separator {
     BeginFn,
     BetweenFnArg,
     EndFn,
+    BeginArray,
+    BetweenArray,
 }
 
 struct Mangler<'a> {
@@ -128,12 +130,11 @@ impl<'a> Mangler<'a> {
                     self.push(Separator::EndFn);
                 }
             }
-            Type::Array(..) => {
-                unimplemented!(
-                    "Unable to mangle generic parameter {:?} for '{}'",
-                    ty,
-                    self.input
-                );
+            Type::Array(ref ty, ref len) => {
+                self.push(Separator::BeginArray);
+                self.append_mangled_type(ty, false);
+                self.push(Separator::BetweenArray);
+                self.append_mangled_argument(&GenericArgument::Const(len.clone()), last);
             }
         }
     }


### PR DESCRIPTION
input.rs:

```rs
#[repr(C)]
pub struct MyStruct<T> {
    field: T
}

#[no_mangle]
pub extern "C" fn my_function(x: MyStruct<[u8; 4]>) {}
```

`cbindgen --lang c input.rs`:

```c
#include <stdarg.h>
#include <stdbool.h>
#include <stdint.h>
#include <stdlib.h>

typedef struct MyStruct__________u8__________4 {
  uint8_t field[4];
} MyStruct__________u8__________4;

void my_function(struct MyStruct__________u8__________4 x);
```