### PR TITLE
Parse `unsafe` attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,9 +405,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/expectations/export_name.c
+++ b/tests/expectations/export_name.c
@@ -4,3 +4,5 @@
 #include <stdlib.h>
 
 void do_the_thing_with_export_name(void);
+
+void do_the_thing_with_unsafe_export_name(void);

--- a/tests/expectations/export_name.compat.c
+++ b/tests/expectations/export_name.compat.c
@@ -9,6 +9,8 @@ extern "C" {
 
 void do_the_thing_with_export_name(void);
 
+void do_the_thing_with_unsafe_export_name(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tests/expectations/export_name.cpp
+++ b/tests/expectations/export_name.cpp
@@ -8,4 +8,6 @@ extern "C" {
 
 void do_the_thing_with_export_name();
 
+void do_the_thing_with_unsafe_export_name();
+
 }  // extern "C"

--- a/tests/expectations/export_name.pyx
+++ b/tests/expectations/export_name.pyx
@@ -7,3 +7,5 @@ cdef extern from *:
 cdef extern from *:
 
   void do_the_thing_with_export_name();
+
+  void do_the_thing_with_unsafe_export_name();

--- a/tests/expectations/mangle.c
+++ b/tests/expectations/mangle.c
@@ -15,3 +15,5 @@ typedef struct {
 typedef FooU8 Boo;
 
 void root(Boo x, Bar y);
+
+void unsafe_root(Boo x, Bar y);

--- a/tests/expectations/mangle.compat.c
+++ b/tests/expectations/mangle.compat.c
@@ -20,6 +20,8 @@ extern "C" {
 
 void root(Boo x, Bar y);
 
+void unsafe_root(Boo x, Bar y);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tests/expectations/mangle.cpp
+++ b/tests/expectations/mangle.cpp
@@ -20,4 +20,6 @@ extern "C" {
 
 void root(Boo x, Bar y);
 
+void unsafe_root(Boo x, Bar y);
+
 }  // extern "C"

--- a/tests/expectations/mangle.pyx
+++ b/tests/expectations/mangle.pyx
@@ -16,3 +16,5 @@ cdef extern from *:
   ctypedef FooU8 Boo;
 
   void root(Boo x, Bar y);
+
+  void unsafe_root(Boo x, Bar y);

--- a/tests/expectations/mangle_both.c
+++ b/tests/expectations/mangle_both.c
@@ -15,3 +15,5 @@ typedef struct FooU8 {
 typedef struct FooU8 Boo;
 
 void root(Boo x, enum Bar y);
+
+void unsafe_root(Boo x, enum Bar y);

--- a/tests/expectations/mangle_both.compat.c
+++ b/tests/expectations/mangle_both.compat.c
@@ -20,6 +20,8 @@ extern "C" {
 
 void root(Boo x, enum Bar y);
 
+void unsafe_root(Boo x, enum Bar y);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tests/expectations/mangle_tag.c
+++ b/tests/expectations/mangle_tag.c
@@ -15,3 +15,5 @@ struct FooU8 {
 typedef struct FooU8 Boo;
 
 void root(Boo x, enum Bar y);
+
+void unsafe_root(Boo x, enum Bar y);

--- a/tests/expectations/mangle_tag.compat.c
+++ b/tests/expectations/mangle_tag.compat.c
@@ -20,6 +20,8 @@ extern "C" {
 
 void root(Boo x, enum Bar y);
 
+void unsafe_root(Boo x, enum Bar y);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tests/expectations/mangle_tag.pyx
+++ b/tests/expectations/mangle_tag.pyx
@@ -16,3 +16,5 @@ cdef extern from *:
   ctypedef FooU8 Boo;
 
   void root(Boo x, Bar y);
+
+  void unsafe_root(Boo x, Bar y);

--- a/tests/rust/export_name.rs
+++ b/tests/rust/export_name.rs
@@ -2,3 +2,8 @@
 pub extern "C" fn do_the_thing() {
   println!("doing the thing!");
 }
+
+#[unsafe(export_name = "do_the_thing_with_unsafe_export_name")]
+pub extern "C" fn unsafe_do_the_thing() {
+  println!("doing the thing!");
+}

--- a/tests/rust/mangle.rs
+++ b/tests/rust/mangle.rs
@@ -17,3 +17,9 @@ pub extern "C" fn root(
     x: Boo,
     y: Bar,
 ) { }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn unsafe_root(
+    x: Boo,
+    y: Bar,
+) { }


### PR DESCRIPTION
Closes #1013 . The linked issue is urgent, so @emilio (hope we can resolve the issue as soon as possible).

The dependency `syn` is updated in order to handle the `unsafe` attributes.