### PR TITLE
Explicitly instantiate function return values that are template classes

### DIFF
--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -341,12 +341,14 @@ pub struct ExportConfig {
     pub renaming_overrides_prefixing: bool,
     /// Mangling configuration.
     pub mangle: MangleConfig,
-    /// Whether to instantiate the struct templates that were emitted, as members of a giant struct
-    /// with the name optionally overridden by [`instantiate_monomorphs_struct_name`]. This silences
-    /// warnings and errors for several compiles, notably MSVC.
-    pub instantiate_monomorphs: bool,
+    /// Whether to instantiate the monomorphs of template types used as function return values. This
+    /// is needed for C compatibility, because otherwise compilers warn (gcc/clang) or even reject
+    /// (MSVC) those function definitions. The compensation is made by emitting a single struct with
+    /// one field for each monomorphized type. The emitted wrapper struct's name can optionally be
+    /// overridden by [`return_value_monomorphs_struct_name`].
+    pub instantiate_return_value_monomorphs: bool,
     /// The struct name to use when [`instantiate_monomorphs`] is enabled, ignored otherwise.
-    pub instantiate_monomorphs_struct_name: Option<String>,
+    pub return_value_monomorphs_struct_name: Option<String>,
 }
 
 /// Mangling-specific configuration.

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -341,6 +341,12 @@ pub struct ExportConfig {
     pub renaming_overrides_prefixing: bool,
     /// Mangling configuration.
     pub mangle: MangleConfig,
+    /// Whether to instantiate the struct templates that were emitted, as members of a giant struct
+    /// with the name optionally overridden by [`instantiate_monomorphs_struct_name`]. This silences
+    /// warnings and errors for several compiles, notably MSVC.
+    pub instantiate_monomorphs: bool,
+    /// The struct name to use when [`instantiate_monomorphs`] is enabled, ignored otherwise.
+    pub instantiate_monomorphs_struct_name: Option<String>,
 }
 
 /// Mangling-specific configuration.

--- a/src/bindgen/ir/documentation.rs
+++ b/src/bindgen/ir/documentation.rs
@@ -4,7 +4,7 @@
 
 use crate::bindgen::utilities::SynAttributeHelpers;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Documentation {
     pub doc_comment: Vec<String>,
 }
@@ -27,8 +27,6 @@ impl Documentation {
     }
 
     pub fn none() -> Self {
-        Documentation {
-            doc_comment: Vec::new(),
-        }
+        Self::default()
     }
 }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -317,13 +317,17 @@ impl Enum {
         repr.style != ReprStyle::C
     }
 
-    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>) {
+    pub fn find_return_value_monomorphs(
+        &self,
+        library: &Library,
+        out: &mut std::collections::HashSet<GenericPath>,
+    ) {
         if self.is_generic() {
             return;
         }
         for v in &self.variants {
             if let VariantBody::Body { ref body, .. } = v.body {
-                body.find_monomorphs(library, out);
+                body.find_return_value_monomorphs(library, out);
             }
         }
     }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -317,6 +317,16 @@ impl Enum {
         repr.style != ReprStyle::C
     }
 
+    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>) {
+        if self.is_generic() {
+            return;
+        }
+        for v in &self.variants {
+            if let VariantBody::Body { ref body, .. } = v.body {
+                body.find_monomorphs(library, out);
+            }
+        }
+    }
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
         if self.is_generic() {
             return;

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -129,6 +129,12 @@ impl Function {
         }
     }
 
+    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>) {
+        self.ret.find_monomorphs(library, out, true);
+        for arg in &self.args {
+            arg.ty.find_monomorphs(library, out, false);
+        }
+    }
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
         self.ret.add_monomorphs(library, out);
         for arg in &self.args {

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -129,10 +129,14 @@ impl Function {
         }
     }
 
-    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>) {
-        self.ret.find_monomorphs(library, out, true);
+    pub fn find_return_value_monomorphs(
+        &self,
+        library: &Library,
+        out: &mut std::collections::HashSet<GenericPath>,
+    ) {
+        self.ret.find_return_value_monomorphs(library, out, true);
         for arg in &self.args {
-            arg.ty.find_monomorphs(library, out, false);
+            arg.ty.find_return_value_monomorphs(library, out, false);
         }
     }
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -10,7 +10,7 @@ use crate::bindgen::config::{Config, Language, LayoutConfig};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Constant, Documentation, Field, GenericArgument, GenericParams, Item,
+    AnnotationSet, Cfg, Constant, Documentation, Field, GenericPath, GenericArgument, GenericParams, Item,
     ItemContainer, Path, Repr, ReprAlign, ReprStyle, Type, Typedef,
 };
 use crate::bindgen::library::Library;
@@ -174,6 +174,14 @@ impl Struct {
         }
     }
 
+    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>) {
+        if self.is_generic() {
+            return;
+        }
+        for field in &self.fields {
+            field.ty.find_monomorphs(library, out, false);
+        }
+    }
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
         // Generic structs can instantiate monomorphs only once they've been
         // instantiated. See `instantiate_monomorph` for more details.

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -10,8 +10,8 @@ use crate::bindgen::config::{Config, Language, LayoutConfig};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Constant, Documentation, Field, GenericPath, GenericArgument, GenericParams, Item,
-    ItemContainer, Path, Repr, ReprAlign, ReprStyle, Type, Typedef,
+    AnnotationSet, Cfg, Constant, Documentation, Field, GenericArgument, GenericParams,
+    GenericPath, Item, ItemContainer, Path, Repr, ReprAlign, ReprStyle, Type, Typedef,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -174,12 +174,16 @@ impl Struct {
         }
     }
 
-    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>) {
+    pub fn find_return_value_monomorphs(
+        &self,
+        library: &Library,
+        out: &mut std::collections::HashSet<GenericPath>,
+    ) {
         if self.is_generic() {
             return;
         }
         for field in &self.fields {
-            field.ty.find_monomorphs(library, out, false);
+            field.ty.find_return_value_monomorphs(library, out, false);
         }
     }
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -9,7 +9,7 @@ use syn::ext::IdentExt;
 use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
-use crate::bindgen::ir::{GenericArgument, ItemContainer, GenericParams, GenericPath, Path};
+use crate::bindgen::ir::{GenericArgument, GenericParams, GenericPath, ItemContainer, Path};
 use crate::bindgen::library::Library;
 use crate::bindgen::monomorph::Monomorphs;
 use crate::bindgen::utilities::IterHelpers;
@@ -739,9 +739,14 @@ impl Type {
         self.add_dependencies_ignoring_generics(&GenericParams::default(), library, out)
     }
 
-    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>, is_function_ret_val: bool) {
+    pub fn find_return_value_monomorphs(
+        &self,
+        library: &Library,
+        out: &mut std::collections::HashSet<GenericPath>,
+        is_function_ret_val: bool,
+    ) {
         match *self {
-            Type::Ptr { ref ty, .. } => ty.find_monomorphs(library, out, false),
+            Type::Ptr { ref ty, .. } => ty.find_return_value_monomorphs(library, out, false),
             Type::Path(ref generic) => {
                 if !is_function_ret_val || generic.generics().is_empty() {
                     return;
@@ -752,34 +757,34 @@ impl Type {
                 for item in items {
                     match item {
                         // Constants and statics cannot be function return types
-                        ItemContainer::Constant(_) | ItemContainer::Static(_)  => {}
+                        ItemContainer::Constant(_) | ItemContainer::Static(_) => {}
                         // Opaque items cannot be instantiated (doomed to compilation failure)
                         ItemContainer::OpaqueItem(_) => {}
                         ItemContainer::Typedef(typedef) => {
                             // Typedefs can reference concrete types so we need to recurse deeper
-                            typedef.find_monomorphs(library, out, true);
+                            typedef.find_return_value_monomorphs(library, out, true);
                         }
                         ItemContainer::Struct(s) if s.is_transparent => {
                             if let Some(typedef) = s.as_typedef() {
-                                typedef.find_monomorphs(library, out, true);
+                                typedef.find_return_value_monomorphs(library, out, true);
                             }
                         }
-                        ItemContainer::Struct(_) | ItemContainer::Union(_) | ItemContainer::Enum(_) => {
+                        ItemContainer::Struct(_)
+                        | ItemContainer::Union(_)
+                        | ItemContainer::Enum(_) => {
                             out.insert(generic.clone());
                         }
                     }
                 }
             }
             Type::Primitive(_) => {}
-            Type::Array(ref ty, _) => ty.find_monomorphs(library, out, false),
+            Type::Array(ref ty, _) => ty.find_return_value_monomorphs(library, out, false),
             Type::FuncPtr {
-                ref ret,
-                ref args,
-                ..
+                ref ret, ref args, ..
             } => {
-                ret.find_monomorphs(library, out, true);
+                ret.find_return_value_monomorphs(library, out, true);
                 for (_, ref arg) in args {
-                    arg.find_monomorphs(library, out, false);
+                    arg.find_return_value_monomorphs(library, out, false);
                 }
             }
         }

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -10,8 +10,8 @@ use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, Field, GenericPath, GenericArgument, GenericParams, Item, ItemContainer,
-    Path, Struct, Type,
+    AnnotationSet, Cfg, Documentation, Field, GenericArgument, GenericParams, GenericPath, Item,
+    ItemContainer, Path, Struct, Type,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -102,9 +102,15 @@ impl Typedef {
         }
     }
 
-    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>, is_function_ret_val: bool) {
+    pub fn find_return_value_monomorphs(
+        &self,
+        library: &Library,
+        out: &mut std::collections::HashSet<GenericPath>,
+        is_function_ret_val: bool,
+    ) {
         if !self.is_generic() {
-            self.aliased.find_monomorphs(library, out, is_function_ret_val);
+            self.aliased
+                .find_return_value_monomorphs(library, out, is_function_ret_val);
         }
     }
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -10,7 +10,7 @@ use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, Field, GenericArgument, GenericParams, Item, ItemContainer,
+    AnnotationSet, Cfg, Documentation, Field, GenericPath, GenericArgument, GenericParams, Item, ItemContainer,
     Path, Struct, Type,
 };
 use crate::bindgen::library::Library;
@@ -102,6 +102,11 @@ impl Typedef {
         }
     }
 
+    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>, is_function_ret_val: bool) {
+        if !self.is_generic() {
+            self.aliased.find_monomorphs(library, out, is_function_ret_val);
+        }
+    }
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
         // Generic structs can instantiate monomorphs only once they've been
         // instantiated. See `instantiate_monomorph` for more details.

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -8,8 +8,8 @@ use crate::bindgen::config::{Config, LayoutConfig};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, Field, GenericPath, GenericArgument, GenericParams, Item, ItemContainer,
-    Path, Repr, ReprAlign, ReprStyle,
+    AnnotationSet, Cfg, Documentation, Field, GenericArgument, GenericParams, GenericPath, Item,
+    ItemContainer, Path, Repr, ReprAlign, ReprStyle,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -100,12 +100,16 @@ impl Union {
         }
     }
 
-    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>) {
+    pub fn find_return_value_monomorphs(
+        &self,
+        library: &Library,
+        out: &mut std::collections::HashSet<GenericPath>,
+    ) {
         if self.is_generic() {
             return;
         }
         for field in &self.fields {
-            field.ty.find_monomorphs(library, out, false);
+            field.ty.find_return_value_monomorphs(library, out, false);
         }
     }
 

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -8,7 +8,7 @@ use crate::bindgen::config::{Config, LayoutConfig};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, Field, GenericArgument, GenericParams, Item, ItemContainer,
+    AnnotationSet, Cfg, Documentation, Field, GenericPath, GenericArgument, GenericParams, Item, ItemContainer,
     Path, Repr, ReprAlign, ReprStyle,
 };
 use crate::bindgen::library::Library;
@@ -97,6 +97,15 @@ impl Union {
     pub fn simplify_standard_types(&mut self, config: &Config) {
         for field in &mut self.fields {
             field.ty.simplify_standard_types(config);
+        }
+    }
+
+    pub fn find_monomorphs(&self, library: &Library, out: &mut std::collections::HashSet<GenericPath>) {
+        if self.is_generic() {
+            return;
+        }
+        for field in &self.fields {
+            field.ty.find_monomorphs(library, out, false);
         }
     }
 

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -10,8 +10,7 @@ use crate::bindgen::config::{Config, Language, SortKey};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::error::Error;
-use crate::bindgen::ir::{Constant, Enum, Function, Item, ItemContainer, ItemMap};
-use crate::bindgen::ir::{OpaqueItem, Path, Static, Struct, Typedef, Union};
+use crate::bindgen::ir::{Constant, Enum, Field, Function, Type, Item, GenericPath, ItemContainer, ItemMap, OpaqueItem, Path, Static, Struct, Typedef, Union};
 use crate::bindgen::monomorph::Monomorphs;
 use crate::bindgen::ItemType;
 
@@ -80,6 +79,49 @@ impl Library {
         self.rename_items();
 
         let mut dependencies = Dependencies::new();
+
+        if self.config.language == Language::Cxx && self.config.export.instantiate_monomorphs {
+            let mut found = std::collections::HashSet::new();
+            self.structs.for_all_items(|x| {
+                x.find_monomorphs(&self, &mut found);
+            });
+            self.unions.for_all_items(|x| {
+                x.find_monomorphs(&self, &mut found);
+            });
+            self.enums.for_all_items(|x| {
+                x.find_monomorphs(&self, &mut found);
+            });
+            self.typedefs.for_all_items(|x| {
+                x.find_monomorphs(&self, &mut found, false);
+            });
+            for x in &self.functions {
+                x.find_monomorphs(&self, &mut found);
+            }
+
+            // Emit all instantiated monomorphs as fields of a giant struct, which silences warnings
+            // and errors on several compilers.
+            let struct_name = match self.config.export.instantiate_monomorphs_struct_name {
+                Some(ref name) => name,
+                _ => "__cbindgen_monomorph_struct",
+            };
+            let fields = found.into_iter().enumerate().map(|(i, path)| {
+                Field::from_name_and_type(format!("field{}", i), Type::Path(path))
+            }).collect();
+            let monomorph_struct = Struct::new(
+                Path::new(struct_name),
+                Default::default(), // no generic params
+                fields,
+                false, // no tag field
+                false, // not an enum body
+                None, // no special alignment requirements
+                false, // not transparent
+                None, // no conf
+                Default::default(), // no annotations
+                Default::default(), // no documentation
+            );
+            self.structs.try_insert(monomorph_struct);
+            Type::Path(GenericPath::new(Path::new(struct_name), vec![])).add_dependencies(&self, &mut dependencies);
+        }
 
         for function in &self.functions {
             function.add_dependencies(&self, &mut dependencies);


### PR DESCRIPTION
Following the ideas discussed in https://github.com/mozilla/cbindgen/issues/402, search the set of referenced types for templates that are function return values and emit them all as fields of a dummy struct. This silences compiler warnings (clang/gcc) and errors (MSVC) about potential ABI compatibility issues caused by returning template classes by value from `extern "C"` functions. We take the dummy struct approach because explicit instantiation changes semantics of C++ templates and can cause linker errors if multiple compilation units do it -- not good for a general header file.

This behavior is implemented as a new pass (similar to the existing `instantiate_monomorphs` pass) that is controlled by a new export config, `instantiate_return_value_monomorphs`. The name of the dummy struct defaults to `__cbindgen_monomorph_struct` but can be overridden by a second config.

