### PR TITLE
Add support for transparent typedefs (take 2)

### DIFF
--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -368,7 +368,7 @@ impl Builder {
         let mut result = Parse::new();
 
         if self.std_types {
-            result.add_std_types();
+            result.add_std_types(self.config.language);
         }
 
         for x in &self.srcs {

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -18,6 +18,7 @@ use crate::bindgen::ir::{
 };
 use crate::bindgen::language_backend::LanguageBackend;
 use crate::bindgen::library::Library;
+use crate::bindgen::transparent::ResolveTransparentTypes;
 use crate::bindgen::writer::SourceWriter;
 use crate::bindgen::Bindings;
 
@@ -605,6 +606,18 @@ impl Item for Constant {
     }
     fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
         None
+    }
+}
+
+impl ResolveTransparentTypes for Constant {
+    fn resolve_transparent_types(&self, library: &Library) -> Option<Self> {
+        // NOTE: We also need to simplify the literal initializer value to match the underlying
+        // type, but that is true for all transparent structs (not just transparent-typedef
+        // structs), and is handled by the `write` method below.
+        Some(Constant {
+            ty: self.ty.transparent_alias(library, GenericParams::empty())?,
+            ..self.clone()
+        })
     }
 }
 

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -603,7 +603,7 @@ impl Item for Constant {
     fn generic_params(&self) -> &GenericParams {
         GenericParams::empty()
     }
-    fn transparent_alias(&self, _generics: &[GenericArgument], _library: &Library) -> Option<Type> {
+    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
         None
     }
 }

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -13,7 +13,7 @@ use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericArgument, GenericParams, Item,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item,
     ItemContainer, Path, Struct, ToCondition, Type,
 };
 use crate::bindgen::language_backend::LanguageBackend;
@@ -603,9 +603,6 @@ impl Item for Constant {
 
     fn generic_params(&self) -> &GenericParams {
         GenericParams::empty()
-    }
-    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
-        None
     }
 }
 

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -13,8 +13,8 @@ use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item,
-    ItemContainer, Path, Struct, ToCondition, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item, ItemContainer, Path,
+    Struct, ToCondition, Type,
 };
 use crate::bindgen::language_backend::LanguageBackend;
 use crate::bindgen::library::Library;

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -13,8 +13,8 @@ use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericParams, Item, ItemContainer, Path,
-    Struct, ToCondition, Type,
+    AnnotationSet, Cfg, ConditionWrite, Documentation, GenericArgument, GenericParams, Item,
+    ItemContainer, Path, Struct, ToCondition, Type,
 };
 use crate::bindgen::language_backend::LanguageBackend;
 use crate::bindgen::library::Library;
@@ -602,6 +602,9 @@ impl Item for Constant {
 
     fn generic_params(&self) -> &GenericParams {
         GenericParams::empty()
+    }
+    fn transparent_alias(&self, _generics: &[GenericArgument], _library: &Library) -> Option<Type> {
+        None
     }
 }
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -250,12 +250,6 @@ impl EnumVariant {
         }
     }
 
-    fn simplify_standard_types(&mut self, config: &Config) {
-        if let VariantBody::Body { ref mut body, .. } = self.body {
-            body.simplify_standard_types(config);
-        }
-    }
-
     fn add_dependencies(&self, library: &Library, out: &mut Dependencies) {
         if let VariantBody::Body { ref body, .. } = self.body {
             body.add_dependencies(library, out);
@@ -1531,12 +1525,6 @@ impl Enum {
                 write!(out, "return *this;");
                 out.close_brace(false);
             }
-        }
-    }
-
-    pub fn simplify_standard_types(&mut self, config: &Config) {
-        for variant in &mut self.variants {
-            variant.simplify_standard_types(config);
         }
     }
 }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -501,7 +501,7 @@ impl Item for Enum {
         &self.generic_params
     }
 
-    fn transparent_alias(&self, _generics: &[GenericArgument], _library: &Library) -> Option<Type> {
+    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
         None
     }
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -501,6 +501,10 @@ impl Item for Enum {
         &self.generic_params
     }
 
+    fn transparent_alias(&self, _generics: &[GenericArgument], _library: &Library) -> Option<Type> {
+        None
+    }
+
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.export_name);
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -503,10 +503,6 @@ impl Item for Enum {
         &self.generic_params
     }
 
-    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
-        None
-    }
-
     fn rename_for_config(&mut self, config: &Config) {
         config.export.rename(&mut self.export_name);
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -10,7 +10,7 @@ use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, AnnotationValue, Cfg, ConditionWrite, DeprecatedNoteKind, Documentation, Field,
+    AnnotationSet, AnnotationValue, Cfg, ConditionWrite, GenericParam, DeprecatedNoteKind, Documentation, Field,
     GenericArgument, GenericParams, GenericPath, Item, ItemContainer, Literal, Path, Repr,
     ReprStyle, Struct, ToCondition, Type,
 };
@@ -20,6 +20,7 @@ use crate::bindgen::mangle;
 use crate::bindgen::monomorph::Monomorphs;
 use crate::bindgen::rename::{IdentifierType, RenameRule};
 use crate::bindgen::reserved;
+use crate::bindgen::transparent::ResolveTransparentTypes;
 use crate::bindgen::writer::{ListType, SourceWriter};
 
 #[allow(clippy::large_enum_variant)]
@@ -642,6 +643,77 @@ impl Item for Enum {
         for variant in &self.variants {
             variant.add_dependencies(library, out);
         }
+    }
+}
+
+impl ResolveTransparentTypes for Enum {
+    fn resolve_transparent_types(&self, library: &Library) -> Option<Self> {
+        // Resolve any defaults in the generic params
+        let params = &self.generic_params;
+        let new_params: Vec<_> = params.iter().map(|param| {
+            match param.default()? {
+                GenericArgument::Type(ty) => {
+                    // NOTE: Param defaults can reference other params
+                    let new_ty = ty.transparent_alias(library, params)?;
+                    let default = Some(GenericArgument::Type(new_ty));
+                    Some(GenericParam::new_type_param(param.name().name(), default))
+                }
+                _ => None,
+            }
+        }).collect();
+        let new_params = new_params.iter().any(Option::is_some).then(|| {
+            let params = new_params.into_iter().zip(&params.0).map(|(new_param, param)| {
+                new_param.unwrap_or_else(|| param.clone())
+            });
+            GenericParams(params.collect())
+        });
+        let params = new_params.as_ref().unwrap_or(params);
+        let mut skip_inline_tag_field = Self::inline_tag_field(&self.repr);
+        let variants: Vec<_> = self.variants.iter().map(|v| match v.body {
+            VariantBody::Body { ref name, ref body, inline, inline_casts } => {
+                let fields: Vec<_> = body.fields.iter().map(|f| {
+                    // Ignore the inline Tag field, if any (it's always first)
+                    if skip_inline_tag_field {
+                        skip_inline_tag_field = false;
+                        None
+                    } else {
+                        Some(Field {
+                            ty: f.ty.transparent_alias(library, params)?,
+                            ..f.clone()
+                        })
+                    }
+                }).collect();
+
+                fields.iter().any(Option::is_some).then(|| {
+                    EnumVariant {
+                        body: VariantBody::Body {
+                            name: name.clone(),
+                            body: Struct {
+                                fields: fields.into_iter().zip(&body.fields).map(|(new_field, field)| {
+                                    new_field.unwrap_or_else(|| field.clone())
+                                }).collect(),
+                                ..body.clone()
+                            },
+                            inline,
+                            inline_casts,
+                        },
+                        ..v.clone()
+                    }
+                })
+            }
+            VariantBody::Empty(..) => None,
+        }).collect();
+
+        if new_params.is_none() && variants.iter().all(Option::is_none) {
+            return None;
+        }
+        Some(Enum {
+            generic_params: new_params.unwrap_or(self.generic_params.clone()),
+            variants: variants.into_iter().zip(&self.variants).map(|(new_variant, variant)| {
+                new_variant.unwrap_or_else(|| variant.clone())
+            }).collect(),
+            ..self.clone()
+        })
     }
 }
 

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -117,13 +117,6 @@ impl Function {
         &self.path
     }
 
-    pub fn simplify_standard_types(&mut self, config: &Config) {
-        self.ret.simplify_standard_types(config);
-        for arg in &mut self.args {
-            arg.ty.simplify_standard_types(config);
-        }
-    }
-
     pub fn add_dependencies(&self, library: &Library, out: &mut Dependencies) {
         self.ret.add_dependencies(library, out);
         for arg in &self.args {

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -9,7 +9,7 @@ use syn::ext::IdentExt;
 use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
-use crate::bindgen::ir::{AnnotationSet, Cfg, Documentation, GenericPath, Path, Type};
+use crate::bindgen::ir::{AnnotationSet, Cfg, GenericParams, Documentation, GenericPath, Path, Type};
 use crate::bindgen::library::Library;
 use crate::bindgen::monomorph::Monomorphs;
 use crate::bindgen::rename::{IdentifierType, RenameRule};
@@ -141,6 +141,29 @@ impl Function {
         for arg in &mut self.args {
             arg.ty.mangle_paths(monomorphs);
         }
+    }
+
+    pub fn resolve_transparent_aliases(&self, library: &Library) -> Option<Function> {
+        // TODO: Dedup with `Type::FuncPtr` case in `Type::transparent_alias`
+        let empty = GenericParams::empty();
+        let new_ret = self.ret.transparent_alias(library, empty);
+        let new_args: Vec<_> = self.args.iter().map(|arg| arg.ty.transparent_alias(library, empty)).collect();
+        (new_ret.is_some() || new_args.iter().any(|arg| arg.is_some())).then(|| {
+            Function {
+                ret: new_ret.unwrap_or_else(|| self.ret.clone()),
+                args: new_args
+                    .into_iter()
+                    .zip(&self.args)
+                    .map(|(ty, arg)| {
+                        FunctionArgument {
+                            ty: ty.unwrap_or_else(|| arg.ty.clone()),
+                            ..arg.clone()
+                        }
+                    })
+                    .collect(),
+                ..self.clone()
+            }
+        })
     }
 
     pub fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -144,29 +144,6 @@ impl Function {
         }
     }
 
-    pub fn resolve_transparent_aliases(&self, library: &Library) -> Option<Function> {
-        // TODO: Dedup with `Type::FuncPtr` case in `Type::transparent_alias`
-        let empty = GenericParams::empty();
-        let new_ret = self.ret.transparent_alias(library, empty);
-        let new_args: Vec<_> = self.args.iter().map(|arg| arg.ty.transparent_alias(library, empty)).collect();
-        (new_ret.is_some() || new_args.iter().any(|arg| arg.is_some())).then(|| {
-            Function {
-                ret: new_ret.unwrap_or_else(|| self.ret.clone()),
-                args: new_args
-                    .into_iter()
-                    .zip(&self.args)
-                    .map(|(ty, arg)| {
-                        FunctionArgument {
-                            ty: ty.unwrap_or_else(|| arg.ty.clone()),
-                            ..arg.clone()
-                        }
-                    })
-                    .collect(),
-                ..self.clone()
-            }
-        })
-    }
-
     pub fn resolve_declaration_types(&mut self, resolver: &DeclarationTypeResolver) {
         self.ret.resolve_declaration_types(resolver);
         for arg in &mut self.args {

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -10,7 +10,9 @@ use syn::ext::IdentExt;
 use crate::bindgen::config::{Config, Language};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
-use crate::bindgen::ir::{AnnotationSet, Cfg, GenericParams, Documentation, GenericPath, Path, Type};
+use crate::bindgen::ir::{
+    AnnotationSet, Cfg, Documentation, GenericParams, GenericPath, Path, Type,
+};
 use crate::bindgen::library::Library;
 use crate::bindgen::monomorph::Monomorphs;
 use crate::bindgen::rename::{IdentifierType, RenameRule};
@@ -218,16 +220,20 @@ impl ResolveTransparentTypes for Function {
     fn resolve_transparent_types(&self, library: &Library) -> Option<Function> {
         let empty = GenericParams::empty();
         let ret = self.ret.transparent_alias_cow(library, empty);
-        let new_args: Vec<_> = self.args.iter().cow_map(|arg| {
-            Some(FunctionArgument {
-                ty: arg.ty.transparent_alias(library, empty)?,
-                ..arg.clone()
+        let args: Vec<_> = self
+            .args
+            .iter()
+            .cow_map(|arg| {
+                Some(FunctionArgument {
+                    ty: arg.ty.transparent_alias(library, empty)?,
+                    ..arg.clone()
+                })
             })
-        }).collect();
+            .collect();
 
-        (ret.cow_is_owned() || new_args.iter().any_owned()).then(|| Function {
+        (ret.cow_is_owned() || args.iter().any_owned()).then(|| Function {
             ret: ret.into_owned(),
-            args: new_args.into_iter().map(Cow::into_owned).collect(),
+            args: args.into_iter().map(Cow::into_owned).collect(),
             ..self.clone()
         })
     }

--- a/src/bindgen/ir/generic_path.rs
+++ b/src/bindgen/ir/generic_path.rs
@@ -25,11 +25,11 @@ pub struct GenericParam {
 }
 
 impl GenericParam {
-    pub fn new_type_param(name: &str) -> Self {
+    pub fn new_type_param(name: &str, default: Option<GenericArgument>) -> Self {
         GenericParam {
             name: Path::new(name),
             ty: GenericParamType::Type,
-            default: None,
+            default,
         }
     }
 
@@ -79,6 +79,9 @@ impl GenericParam {
 
     pub fn name(&self) -> &Path {
         &self.name
+    }
+    pub fn default(&self) -> Option<&GenericArgument> {
+        self.default.as_ref()
     }
 }
 

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -6,8 +6,7 @@ use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, GenericParams, Item, ItemContainer, Path,
-    Type,
+    AnnotationSet, Cfg, Documentation, GenericParams, Item, ItemContainer, Path, Type,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::transparent::ResolveTransparentTypes;

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -6,7 +6,7 @@ use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, GenericArgument, GenericParams, Item, ItemContainer, Path,
+    AnnotationSet, Cfg, Documentation, GenericParams, Item, ItemContainer, Path,
     Type,
 };
 use crate::bindgen::library::Library;
@@ -109,10 +109,6 @@ impl Item for Static {
 
     fn generic_params(&self) -> &GenericParams {
         GenericParams::empty()
-    }
-
-    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
-        None
     }
 
     fn add_dependencies(&self, library: &Library, out: &mut Dependencies) {

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -110,7 +110,7 @@ impl Item for Static {
         GenericParams::empty()
     }
 
-    fn transparent_alias(&self, _generics: &[GenericArgument], _library: &Library) -> Option<Type> {
+    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
         None
     }
 

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -6,7 +6,8 @@ use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, GenericParams, Item, ItemContainer, Path, Type,
+    AnnotationSet, Cfg, Documentation, GenericArgument, GenericParams, Item, ItemContainer, Path,
+    Type,
 };
 use crate::bindgen::library::Library;
 
@@ -107,6 +108,10 @@ impl Item for Static {
 
     fn generic_params(&self) -> &GenericParams {
         GenericParams::empty()
+    }
+
+    fn transparent_alias(&self, _generics: &[GenericArgument], _library: &Library) -> Option<Type> {
+        None
     }
 
     fn add_dependencies(&self, library: &Library, out: &mut Dependencies) {

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -10,6 +10,7 @@ use crate::bindgen::ir::{
     Type,
 };
 use crate::bindgen::library::Library;
+use crate::bindgen::transparent::ResolveTransparentTypes;
 
 #[derive(Debug, Clone)]
 pub struct Static {
@@ -116,5 +117,14 @@ impl Item for Static {
 
     fn add_dependencies(&self, library: &Library, out: &mut Dependencies) {
         self.ty.add_dependencies(library, out);
+    }
+}
+
+impl ResolveTransparentTypes for Static {
+    fn resolve_transparent_types(&self, library: &Library) -> Option<Self> {
+        Some(Static {
+            ty: self.ty.transparent_alias(library, GenericParams::empty())?,
+            ..self.clone()
+        })
     }
 }

--- a/src/bindgen/ir/global.rs
+++ b/src/bindgen/ir/global.rs
@@ -64,10 +64,6 @@ impl Static {
             documentation,
         }
     }
-
-    pub fn simplify_standard_types(&mut self, config: &Config) {
-        self.ty.simplify_standard_types(config);
-    }
 }
 
 impl Item for Static {

--- a/src/bindgen/ir/item.rs
+++ b/src/bindgen/ir/item.rs
@@ -43,7 +43,7 @@ pub trait Item {
         !self.generic_params().is_empty()
     }
 
-    fn transparent_alias(&self, generics: &[GenericArgument], _library: &Library) -> Option<Type>;
+    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type>;
     fn rename_for_config(&mut self, _config: &Config) {}
     fn add_dependencies(&self, _library: &Library, _out: &mut Dependencies) {}
     fn instantiate_monomorph(

--- a/src/bindgen/ir/item.rs
+++ b/src/bindgen/ir/item.rs
@@ -43,7 +43,9 @@ pub trait Item {
         !self.generic_params().is_empty()
     }
 
-    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type>;
+    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
+        None // not relevant for most types
+    }
     fn rename_for_config(&mut self, _config: &Config) {}
     fn add_dependencies(&self, _library: &Library, _out: &mut Dependencies) {}
     fn instantiate_monomorph(

--- a/src/bindgen/ir/item.rs
+++ b/src/bindgen/ir/item.rs
@@ -10,7 +10,7 @@ use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
     AnnotationSet, Cfg, Constant, Documentation, Enum, GenericArgument, GenericParams, OpaqueItem,
-    Path, Static, Struct, Type, Typedef, Union,
+    Path, Static, Struct, Typedef, Union,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::monomorph::Monomorphs;
@@ -43,9 +43,6 @@ pub trait Item {
         !self.generic_params().is_empty()
     }
 
-    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
-        None // not relevant for most types
-    }
     fn rename_for_config(&mut self, _config: &Config) {}
     fn add_dependencies(&self, _library: &Library, _out: &mut Dependencies) {}
     fn instantiate_monomorph(

--- a/src/bindgen/ir/item.rs
+++ b/src/bindgen/ir/item.rs
@@ -10,7 +10,7 @@ use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
     AnnotationSet, Cfg, Constant, Documentation, Enum, GenericArgument, GenericParams, OpaqueItem,
-    Path, Static, Struct, Typedef, Union,
+    Path, Static, Struct, Type, Typedef, Union,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::monomorph::Monomorphs;
@@ -43,6 +43,7 @@ pub trait Item {
         !self.generic_params().is_empty()
     }
 
+    fn transparent_alias(&self, generics: &[GenericArgument], _library: &Library) -> Option<Type>;
     fn rename_for_config(&mut self, _config: &Config) {}
     fn add_dependencies(&self, _library: &Library, _out: &mut Dependencies) {}
     fn instantiate_monomorph(
@@ -66,8 +67,10 @@ pub enum ItemContainer {
     Typedef(Typedef),
 }
 
-impl ItemContainer {
-    pub fn deref(&self) -> &dyn Item {
+impl std::ops::Deref for ItemContainer {
+    type Target = dyn Item + 'static;
+
+    fn deref(&self) -> &Self::Target {
         match *self {
             ItemContainer::Constant(ref x) => x,
             ItemContainer::Static(ref x) => x,

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -7,6 +7,7 @@ use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
     AnnotationSet, Cfg, Documentation, GenericArgument, GenericParams, Item, ItemContainer, Path,
+    Type,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -92,6 +93,10 @@ impl Item for OpaqueItem {
 
     fn generic_params(&self) -> &GenericParams {
         &self.generic_params
+    }
+
+    fn transparent_alias(&self, generics: &[GenericArgument], _library: &Library) -> Option<Type> {
+        None // TODO!
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::borrow::Cow;
+
 use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
@@ -183,9 +185,12 @@ impl Item for OpaqueItem {
 
 impl ResolveTransparentTypes for OpaqueItem {
     fn resolve_transparent_types(&self, library: &Library) -> Option<Self> {
-        Some(OpaqueItem {
-            generic_params: Self::resolve_generic_params(library, &self.generic_params)?,
-            ..self.clone()
-        })
+        match Self::resolve_generic_params(library, &self.generic_params) {
+            Cow::Owned(generic_params) => Some(OpaqueItem {
+                generic_params,
+                ..self.clone()
+            }),
+            _ => None
+        }
     }
 }

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -112,7 +112,7 @@ impl Item for OpaqueItem {
                     is_ref: false,
                 })
             }
-                "NonZero" => return ty.make_zeroable(false),
+            "NonZero" => return ty.make_zeroable(false),
             "Option" => ty.make_nullable().or_else(|| ty.make_zeroable(true))?,
             _ => return None,
         };

--- a/src/bindgen/ir/opaque.rs
+++ b/src/bindgen/ir/opaque.rs
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
-
 use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, GenericArgument, GenericParam, GenericParams, Item, ItemContainer, Path,
+    AnnotationSet, Cfg, Documentation, GenericArgument, GenericParams, Item, ItemContainer, Path,
     Type,
 };
 use crate::bindgen::library::Library;
@@ -185,28 +183,8 @@ impl Item for OpaqueItem {
 
 impl ResolveTransparentTypes for OpaqueItem {
     fn resolve_transparent_types(&self, library: &Library) -> Option<Self> {
-        // Resolve any defaults in the generic params
-        let params = &self.generic_params;
-        let new_params: Vec<_> = params.iter().map(|param| {
-            match param.default()? {
-                GenericArgument::Type(ty) => {
-                    // NOTE: Param defaults can reference other params
-                    let new_ty = ty.transparent_alias(library, params)?;
-                    let default = Some(GenericArgument::Type(new_ty));
-                    Some(GenericParam::new_type_param(param.name().name(), default))
-                }
-                _ => None,
-            }
-        }).collect();
-
-        if new_params.iter().all(Option::is_none) {
-            return None;
-        }
-        let params = new_params.into_iter().zip(&params.0).map(|(new_param, param)| {
-            new_param.unwrap_or_else(|| param.clone())
-        });
         Some(OpaqueItem {
-            generic_params: GenericParams(params.collect()),
+            generic_params: Self::resolve_generic_params(library, &self.generic_params)?,
             ..self.clone()
         })
     }

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -168,10 +168,9 @@ impl Struct {
 
     /// Attempts to convert this struct to a typedef (only works for transparent structs).
     pub fn as_typedef(&self) -> Option<Typedef> {
-        match self.fields.first() {
-            Some(field) if self.is_transparent => Some(Typedef::new_from_struct_field(self, field)),
-            _ => None,
-        }
+        let field = self.fields.first()?;
+        self.is_transparent.then(|| Typedef::new_from_struct_field(self, field))
+            //.inspect(|field| warn!("FRJ replaced {self:#?}\nwith {field:#?}"))
     }
 
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
@@ -354,7 +353,7 @@ impl Item for Struct {
         let Some(typedef) = self.as_typedef() else {
             return None;
         };
-        typedef.transparent_alias(library, args, params).or(Some(typedef.aliased))
+        typedef.transparent_alias(library, args, params)
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -313,10 +313,9 @@ impl Item for Struct {
     }
 
     fn transparent_alias(&self, library: &Library, args: &[GenericArgument], params: &GenericParams) -> Option<Type> {
-        let Some(typedef) = self.as_typedef() else {
-            return None;
-        };
-        typedef.transparent_alias(library, args, params)
+        self.as_typedef().and_then(|typedef| {
+            typedef.transparent_alias(library, args, params)
+        })
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -164,8 +164,13 @@ impl Struct {
     /// Attempts to convert this struct to a typedef (only works for transparent structs).
     pub fn as_typedef(&self) -> Option<Typedef> {
         let field = self.fields.first()?;
-        self.is_transparent.then(|| Typedef::new_from_struct_field(self, field))
-            //.inspect(|field| warn!("FRJ replaced {self:#?}\nwith {field:#?}"))
+        self.is_transparent
+            .then(|| Typedef::new_from_struct_field(self, field))
+    }
+
+    pub fn transparent_alias(&self, args: &[GenericArgument]) -> Option<Type> {
+        self.as_typedef()
+            .and_then(|typedef| typedef.transparent_alias(args))
     }
 
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
@@ -304,12 +309,6 @@ impl Item for Struct {
 
     fn generic_params(&self) -> &GenericParams {
         &self.generic_params
-    }
-
-    fn transparent_alias(&self, library: &Library, args: &[GenericArgument], params: &GenericParams) -> Option<Type> {
-        self.as_typedef().and_then(|typedef| {
-            typedef.transparent_alias(library, args, params)
-        })
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -18,6 +18,7 @@ use crate::bindgen::mangle;
 use crate::bindgen::monomorph::Monomorphs;
 use crate::bindgen::rename::{IdentifierType, RenameRule};
 use crate::bindgen::reserved;
+use crate::bindgen::transparent::ResolveTransparentTypes;
 use crate::bindgen::utilities::IterHelpers;
 use crate::bindgen::writer::SourceWriter;
 
@@ -444,5 +445,46 @@ impl Item for Struct {
         let mappings = self.generic_params.call(self.path.name(), generic_values);
         let monomorph = self.specialize(generic_values, &mappings, library.get_config());
         out.insert_struct(library, self, monomorph, generic_values.to_owned());
+    }
+}
+
+impl ResolveTransparentTypes for Struct {
+    fn resolve_transparent_types(&self, library: &Library) -> Option<Struct> {
+        // Resolve any defaults in the generic params
+        let params = &self.generic_params;
+        let new_params: Vec<_> = params.iter().map(|param| {
+            match param.default()? {
+                GenericArgument::Type(ty) => {
+                    // NOTE: Param defaults can reference other params
+                    let new_ty = ty.transparent_alias(library, params)?;
+                    let default = Some(GenericArgument::Type(new_ty));
+                    Some(GenericParam::new_type_param(param.name().name(), default))
+                }
+                _ => None,
+            }
+        }).collect();
+        let new_params = new_params.iter().any(Option::is_some).then(|| {
+            let params = new_params.into_iter().zip(&params.0).map(|(new_param, param)| {
+                new_param.unwrap_or_else(|| param.clone())
+            });
+            GenericParams(params.collect())
+        });
+        let params = new_params.as_ref().unwrap_or(params);
+        let types: Vec<_> = self.fields.iter().map(|f| f.ty.transparent_alias(library, params)).collect();
+        if new_params.is_none() && types.iter().all(Option::is_none) {
+            return None;
+        }
+        let fields = types.into_iter().zip(&self.fields).map(|(ty, field)| {
+            warn!("Type of field {:?} changed from {ty:#?}\nto {:#?}", field.name, field.ty);
+            Field {
+                ty: ty.unwrap_or_else(|| field.ty.clone()),
+                ..field.clone()
+            }
+        }).collect();
+        Some(Struct {
+            generic_params: new_params.unwrap_or(self.generic_params.clone()),
+            fields,
+            ..self.clone()
+        })
     }
 }

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -10,7 +10,7 @@ use crate::bindgen::config::{Config, Language, LayoutConfig};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Constant, Documentation, Field, GenericArgument, GenericParams, Item,
+    AnnotationSet, Cfg, Constant, GenericParam, Documentation, Field, GenericArgument, GenericParams, Item,
     ItemContainer, Path, Repr, ReprAlign, ReprStyle, Type, Typedef,
 };
 use crate::bindgen::library::Library;
@@ -193,8 +193,28 @@ impl Struct {
     }
 
     pub fn resolve_transparent_aliases(&self, library: &Library) -> Option<Struct> {
-        let types: Vec<_> = self.fields.iter().map(|f| f.ty.transparent_alias(library)).collect();
-        if types.iter().all(Option::is_none) {
+        // Resolve any defaults in the generic params
+        let params = &self.generic_params;
+        let new_params: Vec<_> = params.iter().map(|param| {
+            match param.default()? {
+                GenericArgument::Type(ty) => {
+                    // NOTE: Param defaults can reference other params
+                    let new_ty = ty.transparent_alias(library, params)?;
+                    let default = Some(GenericArgument::Type(new_ty));
+                    Some(GenericParam::new_type_param(param.name().name(), default))
+                }
+                _ => None,
+            }
+        }).collect();
+        let new_params = new_params.iter().any(Option::is_some).then(|| {
+            let params = new_params.into_iter().zip(&params.0).map(|(new_param, param)| {
+                new_param.unwrap_or_else(|| param.clone())
+            });
+            GenericParams(params.collect())
+        });
+        let params = new_params.as_ref().unwrap_or(params);
+        let types: Vec<_> = self.fields.iter().map(|f| f.ty.transparent_alias(library, params)).collect();
+        if new_params.is_none() && types.iter().all(Option::is_none) {
             return None;
         }
         let fields = types.into_iter().zip(&self.fields).map(|(ty, field)| {
@@ -204,6 +224,7 @@ impl Struct {
             }
         }).collect();
         Some(Struct {
+            generic_params: new_params.unwrap_or(self.generic_params.clone()),
             fields,
             ..self.clone()
         })
@@ -329,8 +350,11 @@ impl Item for Struct {
         &self.generic_params
     }
 
-    fn transparent_alias(&self, generics: &[GenericArgument], library: &Library) -> Option<Type> {
-        self.as_typedef().and_then(|t| t.transparent_alias(generics, library))
+    fn transparent_alias(&self, library: &Library, args: &[GenericArgument], params: &GenericParams) -> Option<Type> {
+        let Some(typedef) = self.as_typedef() else {
+            return None;
+        };
+        typedef.transparent_alias(library, args, params).or(Some(typedef.aliased))
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -161,12 +161,6 @@ impl Struct {
         }
     }
 
-    pub fn simplify_standard_types(&mut self, config: &Config) {
-        for field in &mut self.fields {
-            field.ty.simplify_standard_types(config);
-        }
-    }
-
     /// Attempts to convert this struct to a typedef (only works for transparent structs).
     pub fn as_typedef(&self) -> Option<Typedef> {
         let field = self.fields.first()?;

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 use syn::ext::IdentExt;
 
-use crate::bindgen::config::{Config};
+use crate::bindgen::config::Config;
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{GenericArgument, GenericParams, GenericPath, Path};
@@ -573,86 +573,54 @@ impl Type {
     }
 
     /// Convenience wrapper for callers who prefer `Cow` result over `Option`.
-    pub fn transparent_alias_cow<'a>(&'a self, library: &Library, params: &GenericParams) -> Cow<'a, Type> {
-        self.transparent_alias(library, params).map_or_else(|| Cow::Borrowed(self), Cow::Owned)
+    pub fn transparent_alias_cow<'a>(
+        &'a self,
+        library: &Library,
+        params: &GenericParams,
+    ) -> Cow<'a, Type> {
+        self.transparent_alias(library, params)
+            .map_or_else(|| Cow::Borrowed(self), Cow::Owned)
     }
 
     /// If this type is transparent, recursively replace it with whatever type it aliases.
     pub fn transparent_alias(&self, library: &Library, params: &GenericParams) -> Option<Type> {
-        /*
-        if let Some(resolved) = self.transparent_alias_impl(library, params)
-        {
-            warn!("erased {self:#?}\nas {resolved:#?}");
-            Some(resolved)
-        } else if generic_path.{
-            // process the generics first -- they may change even if this type isn't transparent
-            let generics = generic_path.generics();
-            let new_generics: Vec<_> = generics.iter().map(|arg| match arg {
-                GenericArgument::Type(ty) => {
-                    let new_ty = ty.transparent_alias(library, params)?;
-                    //warn!("GenericArgument::Type {ty:#?}\nerased as {new_ty:#?}");
-                    Some(GenericArgument::Type(new_ty))
-                }
-                _ => None
-            }).collect();
-            let new_generics = new_generics.iter().any(Option::is_some).then(|| -> Vec<_> {
-                new_generics.into_iter().zip(generics).map(|(new_arg, arg)| {
-                    new_arg.unwrap_or_else(|| arg.clone())
-                }).collect()
-            });
-            let generics = new_generics.as_ref().map_or(generics, Vec::as_slice);
-        }
-    }
-    pub fn transparent_alias_impl(&self, library: &Library, params: &GenericParams) -> Option<Type> {
-        warn!("Attempt to erase {self:#?}");
-        */
         match *self {
             Type::Ptr {
                 ref ty,
                 is_const,
                 is_nullable,
                 is_ref,
-            } => {
-                let new_ty = ty.transparent_alias(library, params)?;
-                //warn!("Type::Ptr inner {ty:#?}\nerased as {new_ty:#?}");
-                Some(Type::Ptr {
-                    ty: Box::new(new_ty),
-                    is_const,
-                    is_nullable,
-                    is_ref,
-                })
-            }
+            } => Some(Type::Ptr {
+                ty: Box::new(ty.transparent_alias(library, params)?),
+                is_const,
+                is_nullable,
+                is_ref,
+            }),
             Type::Path(ref generic_path) => {
                 let path = generic_path.path();
                 if params.0.iter().any(|p| p.name() == path) {
-                    return None;
+                    return None; // Don't try to resolve template parameters!
                 }
-                // process the generics first -- they may change even if this type isn't transparent
+                // Resolve the generics first -- they may change even if this type isn't transparent
                 let generics = generic_path.generics();
-                let new_generics: Vec<_> = generics.iter().map(|arg| match arg {
-                    GenericArgument::Type(ty) => {
-                        let new_ty = ty.transparent_alias(library, params)?;
-                        //warn!("GenericArgument::Type {ty:#?}\nerased as {new_ty:#?}");
-                        Some(GenericArgument::Type(new_ty))
-                    }
-                    _ => None
-                }).collect();
-                let new_generics = new_generics.iter().any(Option::is_some).then(|| -> Vec<_> {
-                    new_generics.into_iter().zip(generics).map(|(new_arg, arg)| {
-                        new_arg.unwrap_or_else(|| arg.clone())
-                    }).collect()
-                });
+                let new_generics: Vec<_> = generics
+                    .iter()
+                    .cow_map(|arg| match arg {
+                        GenericArgument::Type(ty) => Some(GenericArgument::Type(
+                            ty.transparent_alias(library, params)?,
+                        )),
+                        _ => None,
+                    })
+                    .collect();
+                let new_generics = new_generics
+                    .iter()
+                    .any_owned()
+                    .then(|| new_generics.into_iter().map(Cow::into_owned).collect());
                 let generics = new_generics.as_ref().map_or(generics, Vec::as_slice);
-                let new_ty = TransparentTypeResolver::transparent_alias_for_path(path, generics, library, params);
-                if new_ty.is_some() {
-                    //warn!("Type::Path {self:#?}\nerased as {new_ty:#?}");
-                    new_ty
-                } else {
-                    //if let Some(ref new_generics) = new_generics {
-                    //    warn!("Type::Path args {path:?} simplified to {new_generics:#?}");
-                    //}
-                    new_generics.map(|g| Type::Path(GenericPath::new(path.clone(), g)))
-                }
+                let ty = TransparentTypeResolver::transparent_alias_for_path(
+                    path, generics, library, params,
+                );
+                ty.or_else(|| Some(Type::Path(GenericPath::new(path.clone(), new_generics?))))
             }
             Type::Primitive(_) => None,
             Type::Array(ref ty, ref expr) => Some(Type::Array(
@@ -666,14 +634,16 @@ impl Type {
                 never_return,
             } => {
                 let ret = ret.transparent_alias_cow(library, params);
-                let new_args: Vec<_> = args.iter().cow_map(|arg| {
-                    let ty = arg.1.transparent_alias(library, params)?;
-                    Some((arg.0.clone(), ty))
-                }).collect();
+                let args: Vec<_> = args
+                    .iter()
+                    .cow_map(|(name, ty)| {
+                        Some((name.clone(), ty.transparent_alias(library, params)?))
+                    })
+                    .collect();
 
-                (ret.cow_is_owned() || new_args.iter().any_owned()).then(|| Type::FuncPtr {
+                (ret.cow_is_owned() || args.iter().any_owned()).then(|| Type::FuncPtr {
                     ret: Box::new(ret.into_owned()),
-                    args: new_args.into_iter().map(Cow::into_owned).collect(),
+                    args: args.into_iter().map(Cow::into_owned).collect(),
                     is_nullable,
                     never_return,
                 })

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -627,8 +627,32 @@ impl Type {
         }
     }
 
+    pub fn transparent_alias_for_path(&self, path: &Path, generics: &[GenericArgument], library: &Library, params: &GenericParams) -> Option<Type> {
+        let items = library.get_items(path);
+        if items.is_none() {
+            warn!("Unknown type {path:?}");
+            return None;
+        }
+        let mut erased_types = items
+            .into_iter()
+            .flatten()
+            .flat_map(|item| item.transparent_alias(library, generics, params));
+        let Some(erased_type) = erased_types.next() else {
+            return None;
+        };
+        if let Some(other_erased_type) = erased_types.next() {
+            warn!(
+                "Found multiple erased types for {:?}: {:?} vs. {:?}",
+                path, erased_type, other_erased_type
+            );
+            return None;
+        }
+        // The type we just resolved may itself be transparent... recurse
+        erased_type.transparent_alias(library, params).or(Some(erased_type))
+    }
+
     /// If this type is transparent, recursively replace it with whatever type it aliases.
-    pub fn transparent_alias(&self, library: &Library) -> Option<Type> {
+    pub fn transparent_alias(&self, library: &Library, params: &GenericParams) -> Option<Type> {
         match self {
             Type::Ptr {
                 ty,
@@ -636,30 +660,41 @@ impl Type {
                 is_nullable,
                 is_ref,
             } => Some(Type::Ptr {
-                ty: Box::new(ty.transparent_alias(library)?),
+                ty: Box::new(ty.transparent_alias(library, params)?),
                 is_const: *is_const,
                 is_nullable: *is_nullable,
                 is_ref: *is_ref,
             }),
             Type::Path(generic_path) => {
-                let mut erased_types = library
-                    .get_items(generic_path.path())
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|item| item.transparent_alias(generic_path.generics(), library));
-                let erased_type = erased_types.next()?;
-                if let Some(other_erased_type) = erased_types.next() {
-                    warn!(
-                        "Found multiple erased types for {:?}: {:?} vs. {:?}",
-                        generic_path, erased_type, other_erased_type
-                    );
+                let path = generic_path.path();
+                if params.0.iter().any(|p| p.name() == path) {
                     return None;
                 }
-                Some(erased_type)
+                // process the generics first -- they may change even if this type isn't transparent
+                let generics = generic_path.generics();
+                let new_generics: Vec<_> = generics.iter().map(|arg| match arg {
+                    GenericArgument::Type(ty) => {
+                        let new_ty = ty.transparent_alias(library, params)?;
+                        Some(GenericArgument::Type(new_ty))
+                    }
+                    _ => None
+                }).collect();
+                let new_generics = new_generics.iter().any(Option::is_some).then(|| -> Vec<_> {
+                    new_generics.into_iter().zip(generics).map(|(new_arg, arg)| {
+                        new_arg.unwrap_or_else(|| arg.clone())
+                    }).collect()
+                });
+                let generics = new_generics.as_ref().map_or(generics, Vec::as_slice);
+                let new_ty = self.transparent_alias_for_path(path, generics, library, params);
+                if new_ty.is_some() {
+                    new_ty
+                } else {
+                    new_generics.map(|g| Type::Path(GenericPath::new(path.clone(), g)))
+                }
             }
             Type::Primitive(_) => None,
             Type::Array(ty, expr) => Some(Type::Array(
-                Box::new(ty.transparent_alias(library)?),
+                Box::new(ty.transparent_alias(library, params)?),
                 expr.clone(),
             )),
             Type::FuncPtr {
@@ -668,8 +703,8 @@ impl Type {
                 is_nullable,
                 never_return,
             } => {
-                let new_ret = ret.transparent_alias(library);
-                let new_args: Vec<_> = args.iter().map(|(_, ty)| ty.transparent_alias(library)).collect();
+                let new_ret = ret.transparent_alias(library, params);
+                let new_args: Vec<_> = args.iter().map(|(_, ty)| ty.transparent_alias(library, params)).collect();
                 (new_ret.is_some() || new_args.iter().any(|arg| arg.is_some())).then(|| {
                     Type::FuncPtr {
                         ret: Box::new(new_ret.unwrap_or_else(|| ret.as_ref().clone())),

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashMap;
+
 use syn::ext::IdentExt;
 
 use crate::bindgen::config::Config;

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -68,10 +68,6 @@ impl Typedef {
         }
     }
 
-    pub fn simplify_standard_types(&mut self, config: &Config) {
-        self.aliased.simplify_standard_types(config);
-    }
-
     // Used to convert a transparent Struct to a Typedef.
     pub fn new_from_struct_field(item: &Struct, field: &Field) -> Self {
         Self {

--- a/src/bindgen/ir/typedef.rs
+++ b/src/bindgen/ir/typedef.rs
@@ -116,7 +116,7 @@ impl Typedef {
 
     pub fn resolve_transparent_aliases(&self, library: &Library) -> Option<Typedef> {
         Some(Typedef {
-            aliased: self.aliased.transparent_alias(library)?,
+            aliased: self.aliased.transparent_alias(library, &self.generic_params)?,
             ..self.clone()
         })
     }
@@ -163,13 +163,14 @@ impl Item for Typedef {
         &self.generic_params
     }
 
-    fn transparent_alias(&self, generics: &[GenericArgument], library: &Library) -> Option<Type> {
+    fn transparent_alias(&self, _library: &Library, args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
+        // NOTE: We don't need to resolve params, because our caller will reprocess it. Just
+        // specialize the aliased type (if needed) and return it.
         if self.is_generic() {
-            let mappings = self.generic_params.call(self.path.name(), generics);
-            let aliased = self.aliased.specialize(&mappings);
-            aliased.transparent_alias(library)
+            let mappings = self.generic_params.call(self.path.name(), args);
+            Some(self.aliased.specialize(&mappings))
         } else {
-            self.aliased.transparent_alias(library)
+            Some(self.aliased.clone())
         }
     }
 

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -95,12 +95,6 @@ impl Union {
         }
     }
 
-    pub fn simplify_standard_types(&mut self, config: &Config) {
-        for field in &mut self.fields {
-            field.ty.simplify_standard_types(config);
-        }
-    }
-
     pub fn add_monomorphs(&self, library: &Library, out: &mut Monomorphs) {
         // Generic unions can instantiate monomorphs only once they've been
         // instantiated. See `instantiate_monomorph` for more details.

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -255,7 +255,6 @@ impl Item for Union {
 
 impl ResolveTransparentTypes for Union {
     fn resolve_transparent_types(&self, library: &Library) -> Option<Self> {
-        // Resolve any defaults in the generic params
         let params = Self::resolve_generic_params(library, &self.generic_params);
         let fields = Self::resolve_fields(library, &self.fields, &params, false);
         (params.cow_is_owned() || fields.cow_is_owned()).then(|| Union {

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -9,7 +9,7 @@ use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
     AnnotationSet, Cfg, Documentation, Field, GenericArgument, GenericParams, Item, ItemContainer,
-    Path, Repr, ReprAlign, ReprStyle,
+    Path, Repr, ReprAlign, ReprStyle, Type,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -160,6 +160,10 @@ impl Item for Union {
 
     fn generic_params(&self) -> &GenericParams {
         &self.generic_params
+    }
+
+    fn transparent_alias(&self, _generics: &[GenericArgument], _library: &Library) -> Option<Type> {
+        None
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -9,7 +9,7 @@ use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
     AnnotationSet, Cfg, Documentation, Field, GenericArgument, GenericParams, Item, ItemContainer,
-    Path, Repr, ReprAlign, ReprStyle, Type,
+    Path, Repr, ReprAlign, ReprStyle,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
@@ -161,10 +161,6 @@ impl Item for Union {
 
     fn generic_params(&self) -> &GenericParams {
         &self.generic_params
-    }
-
-    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
-        None
     }
 
     fn rename_for_config(&mut self, config: &Config) {

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -162,7 +162,7 @@ impl Item for Union {
         &self.generic_params
     }
 
-    fn transparent_alias(&self, _generics: &[GenericArgument], _library: &Library) -> Option<Type> {
+    fn transparent_alias(&self, _library: &Library, _args: &[GenericArgument], _params: &GenericParams) -> Option<Type> {
         None
     }
 

--- a/src/bindgen/ir/union.rs
+++ b/src/bindgen/ir/union.rs
@@ -8,13 +8,14 @@ use crate::bindgen::config::{Config, LayoutConfig};
 use crate::bindgen::declarationtyperesolver::DeclarationTypeResolver;
 use crate::bindgen::dependencies::Dependencies;
 use crate::bindgen::ir::{
-    AnnotationSet, Cfg, Documentation, Field, GenericArgument, GenericParams, Item, ItemContainer,
+    AnnotationSet, Cfg, GenericParam, Documentation, Field, GenericArgument, GenericParams, Item, ItemContainer,
     Path, Repr, ReprAlign, ReprStyle, Type,
 };
 use crate::bindgen::library::Library;
 use crate::bindgen::mangle;
 use crate::bindgen::monomorph::Monomorphs;
 use crate::bindgen::rename::{IdentifierType, RenameRule};
+use crate::bindgen::transparent::ResolveTransparentTypes;
 use crate::bindgen::utilities::IterHelpers;
 
 #[derive(Debug, Clone)]
@@ -259,5 +260,48 @@ impl Item for Union {
         );
 
         out.insert_union(library, self, monomorph, generic_values.to_owned());
+    }
+}
+
+impl ResolveTransparentTypes for Union {
+    fn resolve_transparent_types(&self, library: &Library) -> Option<Self> {
+        // Resolve any defaults in the generic params
+        let params = &self.generic_params;
+        let new_params: Vec<_> = params.iter().map(|param| {
+            match param.default()? {
+                GenericArgument::Type(ty) => {
+                    // NOTE: Param defaults can reference other params
+                    let new_ty = ty.transparent_alias(library, params)?;
+                    let default = Some(GenericArgument::Type(new_ty));
+                    Some(GenericParam::new_type_param(param.name().name(), default))
+                }
+                _ => None,
+            }
+        }).collect();
+        let new_params = new_params.iter().any(Option::is_some).then(|| {
+            let params = new_params.into_iter().zip(&params.0).map(|(new_param, param)| {
+                new_param.unwrap_or_else(|| param.clone())
+            });
+            GenericParams(params.collect())
+        });
+        let params = new_params.as_ref().unwrap_or(params);
+        let types: Vec<_> = self.fields.iter().map(|f| {
+            Some(Field {
+                ty: f.ty.transparent_alias(library, params)?,
+                ..f.clone()
+            })
+        }).collect();
+        if new_params.is_none() && types.iter().all(Option::is_none) {
+            return None;
+        }
+        let fields = types.into_iter().zip(&self.fields).map(|(new_field, field)| {
+            warn!("Type of field {:?} changed from {:#?}\nto {:#?}", field.name, field.ty, new_field);
+            new_field.unwrap_or_else(|| field.clone())
+        }).collect();
+        Some(Union {
+            generic_params: new_params.unwrap_or(self.generic_params.clone()),
+            fields,
+            ..self.clone()
+        })
     }
 }

--- a/src/bindgen/language_backend/mod.rs
+++ b/src/bindgen/language_backend/mod.rs
@@ -159,12 +159,7 @@ pub trait LanguageBackend: Sized {
 
     fn write_items<W: Write>(&mut self, out: &mut SourceWriter<W>, b: &Bindings) {
         for item in &b.items {
-            if item
-                .deref()
-                .annotations()
-                .bool("no-export")
-                .unwrap_or(false)
-            {
+            if item.annotations().bool("no-export").unwrap_or(false) {
                 continue;
             }
 

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -63,7 +63,6 @@ impl Library {
 
     pub fn generate(mut self) -> Result<Bindings, Error> {
         //self.transfer_annotations();
-        //self.simplify_standard_types();
         self.resolve_transparent_types();
 
         match self.config.function.sort_by.unwrap_or(self.config.sort_by) {
@@ -366,29 +365,6 @@ impl Library {
 
         for item in &mut self.functions {
             item.resolve_declaration_types(&resolver);
-        }
-    }
-
-    fn simplify_standard_types(&mut self) {
-        let config = &self.config;
-
-        self.structs.for_all_items_mut(|x| {
-            x.simplify_standard_types(config);
-        });
-        self.enums.for_all_items_mut(|x| {
-            x.simplify_standard_types(config);
-        });
-        self.unions.for_all_items_mut(|x| {
-            x.simplify_standard_types(config);
-        });
-        self.globals.for_all_items_mut(|x| {
-            x.simplify_standard_types(config);
-        });
-        self.typedefs.for_all_items_mut(|x| {
-            x.simplify_standard_types(config);
-        });
-        for x in &mut self.functions {
-            x.simplify_standard_types(config);
         }
     }
 

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -61,8 +61,6 @@ impl Library {
     }
 
     pub fn generate(mut self) -> Result<Bindings, Error> {
-        self.transfer_annotations();
-        self.simplify_standard_types();
         self.resolve_transparent_types();
 
         match self.config.function.sort_by.unwrap_or(self.config.sort_by) {

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -62,6 +62,8 @@ impl Library {
     }
 
     pub fn generate(mut self) -> Result<Bindings, Error> {
+        //self.transfer_annotations();
+        //self.simplify_standard_types();
         self.resolve_transparent_types();
 
         match self.config.function.sort_by.unwrap_or(self.config.sort_by) {

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -194,6 +194,7 @@ impl Library {
             .filter(|x| config.export.exclude.iter().any(|y| y == x.path().name()));
     }
 
+    #[allow(unused)]
     fn transfer_annotations(&mut self) {
         let mut annotations = HashMap::new();
 
@@ -369,24 +370,31 @@ impl Library {
     }
 
     fn resolve_transparent_types(&mut self) {
-        let mut resolver = TransparentTypeResolver::default();
-        TransparentTypeResolver::resolve_items(&mut resolver.constants, self, &self.constants);
-        TransparentTypeResolver::resolve_items(&mut resolver.globals, self, &self.globals);
-        TransparentTypeResolver::resolve_items(&mut resolver.enums, self, &self.enums);
-        TransparentTypeResolver::resolve_items(&mut resolver.structs, self, &self.structs);
-        TransparentTypeResolver::resolve_items(&mut resolver.unions, self, &self.unions);
-        TransparentTypeResolver::resolve_items(&mut resolver.opaque_items, self, &self.opaque_items);
-        TransparentTypeResolver::resolve_items(&mut resolver.typedefs, self, &self.typedefs);
-        resolver.resolve_functions(self, &self.functions);
+        let resolver = TransparentTypeResolver;
 
-        TransparentTypeResolver::install_items(&mut resolver.constants, &mut self.constants);
-        TransparentTypeResolver::install_items(&mut resolver.globals, &mut self.globals);
-        TransparentTypeResolver::install_items(&mut resolver.enums, &mut self.enums);
-        TransparentTypeResolver::install_items(&mut resolver.structs, &mut self.structs);
-        TransparentTypeResolver::install_items(&mut resolver.unions, &mut self.unions);
-        TransparentTypeResolver::install_items(&mut resolver.opaque_items, &mut self.opaque_items);
-        TransparentTypeResolver::install_items(&mut resolver.typedefs, &mut self.typedefs);
-        resolver.install_functions(&mut self.functions);
+        let constants = resolver.resolve_items(self, &self.constants);
+        resolver.install_items(constants, &mut self.constants);
+
+        let globals = resolver.resolve_items(self, &self.globals);
+        resolver.install_items(globals, &mut self.globals);
+
+        let enums = resolver.resolve_items(self, &self.enums);
+        resolver.install_items(enums, &mut self.enums);
+
+        let structs = resolver.resolve_items(self, &self.structs);
+        resolver.install_items(structs, &mut self.structs);
+
+        let unions = resolver.resolve_items(self, &self.unions);
+        resolver.install_items(unions, &mut self.unions);
+
+        let opaque_items = resolver.resolve_items(self, &self.opaque_items);
+        resolver.install_items(opaque_items, &mut self.opaque_items);
+
+        let typedefs = resolver.resolve_items(self, &self.typedefs);
+        resolver.install_items(typedefs, &mut self.typedefs);
+
+        let functions = resolver.resolve_functions(self, &self.functions);
+        resolver.install_functions(functions, &mut self.functions);
     }
 
     fn instantiate_monomorphs(&mut self) {

--- a/src/bindgen/library.rs
+++ b/src/bindgen/library.rs
@@ -95,7 +95,7 @@ impl Library {
             if let Some(items) = self.get_items(&path) {
                 if dependencies.items.insert(path) {
                     for item in &items {
-                        item.deref().add_dependencies(&self, &mut dependencies);
+                        item.add_dependencies(&self, &mut dependencies);
                     }
                     for item in items {
                         dependencies.order.push(item);
@@ -388,6 +388,23 @@ impl Library {
         for x in &mut self.functions {
             x.simplify_standard_types(config);
         }
+    }
+
+    fn erase_types(&mut self) {
+        let mut structs = HashMap::new();
+        let mut i = 0;
+        self.structs.for_all_items(|x| {
+            x.resolve_transparent_aliases(self).map(|alias| {
+                structs.insert(i, alias);
+            });
+            i += 1;
+        });
+
+        let mut i = 0;
+        self.structs.for_all_items_mut(|x| {
+            structs.remove(&i).map(|alias| *x = alias);
+            i += 1;
+        });
     }
 
     fn instantiate_monomorphs(&mut self) {

--- a/src/bindgen/mod.rs
+++ b/src/bindgen/mod.rs
@@ -53,6 +53,7 @@ mod monomorph;
 mod parser;
 mod rename;
 mod reserved;
+mod transparent;
 mod utilities;
 mod writer;
 

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -15,8 +15,9 @@ use crate::bindgen::cargo::{Cargo, PackageRef};
 use crate::bindgen::config::{Config, Language, ParseConfig};
 use crate::bindgen::error::Error;
 use crate::bindgen::ir::{
-    AnnotationSet, AnnotationValue, Cfg, Constant, Documentation, Enum, Function, GenericPath, GenericArgument, GenericParam,
-    GenericParams, ItemMap, OpaqueItem, Path, Static, Struct, Type, Typedef, Union,
+    AnnotationSet, AnnotationValue, Cfg, Constant, Documentation, Enum, Function, GenericArgument,
+    GenericParam, GenericParams, GenericPath, ItemMap, OpaqueItem, Path, Static, Struct, Type,
+    Typedef, Union,
 };
 use crate::bindgen::utilities::{SynAbiHelpers, SynAttributeHelpers, SynItemHelpers};
 
@@ -496,7 +497,7 @@ impl Parse {
             self.add_opaque("MaybeUninit", vec!["T"]);
             self.add_opaque("Pin", vec!["T"]);
         } else {
-            // NOTE: Box<T> acts like NonNull<T> in C
+            // NOTE: Box<T> acts like NonNull<T> in C, so emit it as a transparent typedef
             let generics = vec![GenericArgument::Type(tpath.clone())];
             let alias = Type::Path(GenericPath::new(Path::new("NonNull"), generics));
             self.add_transparent_typedef("Box", alias, vec!["T"]);

--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -443,7 +443,7 @@ impl Parse {
             let path = Path::new(path);
             let generic_params: Vec<_> = generic_params
                 .into_iter()
-                .map(GenericParam::new_type_param)
+                .map(|name| GenericParam::new_type_param(name, None))
                 .collect();
             self.opaque_items.try_insert(OpaqueItem::new(
                 path,
@@ -462,6 +462,7 @@ impl Parse {
         add_opaque("Result", vec!["T", "E"]);
         add_opaque("Option", vec!["T"]);
         add_opaque("NonNull", vec!["T"]);
+        add_opaque("NonZero", vec!["T"]);
         add_opaque("Vec", vec!["T"]);
         add_opaque("HashMap", vec!["K", "V", "Hasher"]);
         add_opaque("BTreeMap", vec!["K", "V"]);

--- a/src/bindgen/transparent.rs
+++ b/src/bindgen/transparent.rs
@@ -1,13 +1,62 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::bindgen::ir::{Constant, Static, Enum, Struct, Union, OpaqueItem, Typedef, Function, Item, ItemMap, GenericParams, GenericArgument, GenericParam, Field};
 use crate::bindgen::library::Library;
 
+/// Helper trait that makes it easier to work with `Cow` in iterators
+pub trait IterCow: Iterator {
+    /// Maps from `&T` to `Cow<'a, T>` using the provided closure. If the closure returns `Some`
+    /// result, it is returned as `Cow::Owned`; otherwise, return the item as `Cow::Borrowed`.
+    fn cow_map<'a, F, T>(self, f: F) -> impl Iterator<Item = Cow<'a, T>>
+    where
+        F: FnMut(&T) -> Option<T>,
+        T: Clone + 'a,
+        Self: Iterator<Item = &'a T>;
+
+    /// True if any item is `Cow::Owned`
+    fn any_owned<'i, 'a: 'i, T>(self) -> bool
+    where
+        T: Clone + 'a,
+        Self: Iterator<Item = &'i Cow<'a, T>>;
+}
+
+// Blanket implementation for all iterators
+impl<I: Iterator> IterCow for I {
+    fn cow_map<'a, F, T>(self, mut f: F) -> impl Iterator<Item = Cow<'a, T>>
+    where
+        F: FnMut(&T) -> Option<T>,
+        T: Clone + 'a,
+        Self: Iterator<Item = &'a T>,
+    {
+        self.map(move |item| f(item).map(Cow::Owned).unwrap_or(Cow::Borrowed(item)))
+    }
+
+    fn any_owned<'i, 'a: 'i, T>(mut self) -> bool
+    where
+        T: Clone + 'a,
+        Self: Iterator<Item = &'i Cow<'a, T>>,
+    {
+        self.any(|item| matches!(item, Cow::Owned(_)))
+    }
+
+}
+
+/// Extension trait that compenates for `Cow::is_owned` being unstable
+pub trait CowIsOwned {
+    fn cow_is_owned(&self) -> bool;
+}
+impl<T: Clone> CowIsOwned for Cow<'_, T> {
+    fn cow_is_owned(&self) -> bool {
+        matches!(self, Cow::Owned(_))
+    }
+}
+
 pub trait ResolveTransparentTypes: Sized {
     fn resolve_transparent_types(&self, library: &Library) -> Option<Self>;
 
-    fn resolve_fields(library: &Library, fields: &[Field], params: &GenericParams, mut skip_first: bool) -> Option<Vec<Field>> {
-        let new_fields: Vec<_> = fields.iter().map(|f| {
+    fn resolve_fields<'a>(library: &Library, fields: &'a Vec<Field>, params: &GenericParams, mut skip_first: bool) -> Cow<'a, Vec<Field>> {
+        let new_fields: Vec<_> = fields.iter().cow_map(|f| {
             // Ignore the inline Tag field, if any (it's always first)
             if skip_first {
                 skip_first = false;
@@ -20,34 +69,30 @@ pub trait ResolveTransparentTypes: Sized {
             }
         }).collect();
 
-        if new_fields.iter().all(Option::is_none) {
-            return None;
+        if new_fields.iter().any_owned() {
+            Cow::Owned(new_fields.into_iter().map(Cow::into_owned).collect())
+        } else {
+            Cow::Borrowed(fields)
         }
-        Some(new_fields.into_iter().zip(fields).map(|(new_field, field)| {
-            new_field.unwrap_or_else(|| field.clone())
-        }).collect())
     }
 
-    fn resolve_generic_params(library: &Library, params: &GenericParams) -> Option<GenericParams> {
+    fn resolve_generic_params<'a>(library: &Library, params: &'a GenericParams) -> Cow<'a, GenericParams> {
         // Resolve defaults in the generic params
-        let new_params: Vec<_> = params.iter().map(|param| {
-            match param.default()? {
-                GenericArgument::Type(ty) => {
-                    // NOTE: Param defaults can reference other params
-                    let new_ty = ty.transparent_alias(library, params)?;
-                    let default = Some(GenericArgument::Type(new_ty));
-                    Some(GenericParam::new_type_param(param.name().name(), default))
-                }
-                _ => None,
+        let new_params: Vec<_> = params.iter().cow_map(|param| match param.default()? {
+            GenericArgument::Type(ty) => {
+                // NOTE: Param defaults can reference other params
+                let new_ty = ty.transparent_alias(library, params)?;
+                let default = Some(GenericArgument::Type(new_ty));
+                Some(GenericParam::new_type_param(param.name().name(), default))
             }
+            _ => None,
         }).collect();
 
-        new_params.iter().any(Option::is_some).then(|| {
-            let params = new_params.into_iter().zip(&params.0).map(|(new_param, param)| {
-                new_param.unwrap_or_else(|| param.clone())
-            });
-            GenericParams(params.collect())
-        })
+        if new_params.iter().any_owned() {
+            Cow::Owned(GenericParams(new_params.into_iter().map(Cow::into_owned).collect()))
+        } else {
+            Cow::Borrowed(params)
+        }
     }
 }
 

--- a/src/bindgen/transparent.rs
+++ b/src/bindgen/transparent.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+
+use crate::bindgen::ir::{Constant, Static, Enum, Struct, Union, OpaqueItem, Typedef, Function, Item, ItemMap};
+use crate::bindgen::library::Library;
+
+pub trait ResolveTransparentTypes: Sized {
+    fn resolve_transparent_types(&self, library: &Library) -> Option<Self>;
+}
+
+pub type ResolvedItems<T> = HashMap<usize, T>;
+
+/// An indirection that allows to generalize the two-stage process of resolving transparent types.
+#[derive(Default)]
+pub struct TransparentTypeResolver {
+    pub constants: ResolvedItems<Constant>,
+    pub globals: ResolvedItems<Static>,
+    pub enums: ResolvedItems<Enum>,
+    pub structs: ResolvedItems<Struct>,
+    pub unions: ResolvedItems<Union>,
+    pub opaque_items: ResolvedItems<OpaqueItem>,
+    pub typedefs: ResolvedItems<Typedef>,
+    pub functions: ResolvedItems<Function>,
+}
+
+impl TransparentTypeResolver {
+    fn resolve_item<T: ResolveTransparentTypes>(item: &T, i: usize, resolved: &mut ResolvedItems<T>, library: &Library) {
+        if let Some(alias) = item.resolve_transparent_types(library) {
+            resolved.insert(i, alias);
+        }
+    }
+
+    // Functions do not impl Item
+    pub fn resolve_functions(&mut self, library: &Library, items: &Vec<Function>) {
+        for (i, item) in items.into_iter().enumerate() {
+            Self::resolve_item(item, i, &mut self.functions, library);
+        }
+    }
+
+    pub fn resolve_items<T: ResolveTransparentTypes + Item + Clone>(resolved: &mut ResolvedItems<T>, library: &Library, items: &ItemMap<T>) {
+        let mut i = 0;
+        items.for_all_items(|item| {
+            Self::resolve_item(item, i, resolved, library);
+            i += 1;
+        });
+    }
+
+    fn install_item<T: ResolveTransparentTypes>(item: &mut T, i: usize, resolved: &mut ResolvedItems<T>) {
+        if let Some(alias) = resolved.remove(&i) {
+            *item = alias;
+        }
+    }
+
+    // Functions do not impl Item
+    pub fn install_functions(&mut self, items: &mut Vec<Function>) {
+        for (i, item) in items.into_iter().enumerate() {
+            Self::install_item(item, i, &mut self.functions);
+        }
+    }
+
+    pub fn install_items<T: ResolveTransparentTypes + Item + Clone>(resolved: &mut ResolvedItems<T>, items: &mut ItemMap<T>) {
+        let mut i = 0;
+        items.for_all_items_mut(|item| {
+            Self::install_item(item, i, resolved);
+            i += 1;
+        });
+    }
+}

--- a/tests/expectations/transparent.c
+++ b/tests/expectations/transparent.c
@@ -7,6 +7,8 @@ typedef struct DummyStruct DummyStruct;
 
 typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
 
+typedef struct StructWithAssociatedConstantInImpl StructWithAssociatedConstantInImpl;
+
 typedef DummyStruct TransparentComplexWrappingStructTuple;
 
 typedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -27,7 +29,21 @@ typedef struct {
 
 } TransparentEmptyStructure;
 
-#define EnumWithAssociatedConstantInImpl_TEN 10
+typedef const uint32_t *TransparentPointerWrappingStructure;
+
+typedef int32_t TransparentIntStruct;
+
+typedef DummyStruct TransparentComplexStruct;
+
+typedef TransparentPrimitiveWrappingStructure TransparentTransparentStruct;
+
+typedef uint32_t *TransparentNonNullStruct;
+
+typedef uint32_t *TransparentOptionNonNullStruct;
+
+#define StructWithAssociatedConstantInImpl_STRUCT_TEN 10
+
+#define EnumWithAssociatedConstantInImpl_ENUM_TEN 10
 
 void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructTuple b,
@@ -37,4 +53,21 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
           TransparentEmptyStructure h,
-          EnumWithAssociatedConstantInImpl i);
+          TransparentPointerWrappingStructure i,
+          StructWithAssociatedConstantInImpl j,
+          EnumWithAssociatedConstantInImpl k);
+
+void erased_root(uint32_t *a,
+                 uint32_t *b,
+                 TransparentPrimitiveWrappingStructure c,
+                 uint32_t *d,
+                 TransparentIntStruct e,
+                 int32_t f,
+                 DummyStruct g,
+                 uint32_t *h,
+                 int32_t i,
+                 TransparentIntStruct j,
+                 TransparentComplexStruct k,
+                 TransparentTransparentStruct l,
+                 TransparentNonNullStruct m,
+                 TransparentOptionNonNullStruct n);

--- a/tests/expectations/transparent.compat.c
+++ b/tests/expectations/transparent.compat.c
@@ -7,6 +7,8 @@ typedef struct DummyStruct DummyStruct;
 
 typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
 
+typedef struct StructWithAssociatedConstantInImpl StructWithAssociatedConstantInImpl;
+
 typedef DummyStruct TransparentComplexWrappingStructTuple;
 
 typedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -27,7 +29,21 @@ typedef struct {
 
 } TransparentEmptyStructure;
 
-#define EnumWithAssociatedConstantInImpl_TEN 10
+typedef const uint32_t *TransparentPointerWrappingStructure;
+
+typedef int32_t TransparentIntStruct;
+
+typedef DummyStruct TransparentComplexStruct;
+
+typedef TransparentPrimitiveWrappingStructure TransparentTransparentStruct;
+
+typedef uint32_t *TransparentNonNullStruct;
+
+typedef uint32_t *TransparentOptionNonNullStruct;
+
+#define StructWithAssociatedConstantInImpl_STRUCT_TEN 10
+
+#define EnumWithAssociatedConstantInImpl_ENUM_TEN 10
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,7 +57,24 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
           TransparentEmptyStructure h,
-          EnumWithAssociatedConstantInImpl i);
+          TransparentPointerWrappingStructure i,
+          StructWithAssociatedConstantInImpl j,
+          EnumWithAssociatedConstantInImpl k);
+
+void erased_root(uint32_t *a,
+                 uint32_t *b,
+                 TransparentPrimitiveWrappingStructure c,
+                 uint32_t *d,
+                 TransparentIntStruct e,
+                 int32_t f,
+                 DummyStruct g,
+                 uint32_t *h,
+                 int32_t i,
+                 TransparentIntStruct j,
+                 TransparentComplexStruct k,
+                 TransparentTransparentStruct l,
+                 TransparentNonNullStruct m,
+                 TransparentOptionNonNullStruct n);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/transparent.cpp
+++ b/tests/expectations/transparent.cpp
@@ -8,6 +8,8 @@ struct DummyStruct;
 
 struct EnumWithAssociatedConstantInImpl;
 
+struct StructWithAssociatedConstantInImpl;
+
 using TransparentComplexWrappingStructTuple = DummyStruct;
 
 using TransparentPrimitiveWrappingStructTuple = uint32_t;
@@ -30,7 +32,21 @@ struct TransparentEmptyStructure {
 
 };
 
-constexpr static const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_TEN = 10;
+using TransparentPointerWrappingStructure = const uint32_t*;
+
+using TransparentIntStruct = int32_t;
+
+using TransparentComplexStruct = DummyStruct;
+
+using TransparentTransparentStruct = TransparentPrimitiveWrappingStructure;
+
+using TransparentNonNullStruct = uint32_t*;
+
+using TransparentOptionNonNullStruct = uint32_t*;
+
+constexpr static const TransparentPrimitiveWrappingStructure StructWithAssociatedConstantInImpl_STRUCT_TEN = 10;
+
+constexpr static const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_ENUM_TEN = 10;
 
 extern "C" {
 
@@ -42,6 +58,23 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrapper<int32_t> f,
           TransparentPrimitiveWithAssociatedConstants g,
           TransparentEmptyStructure h,
-          EnumWithAssociatedConstantInImpl i);
+          TransparentPointerWrappingStructure i,
+          StructWithAssociatedConstantInImpl j,
+          EnumWithAssociatedConstantInImpl k);
+
+void erased_root(uint32_t *a,
+                 uint32_t *b,
+                 TransparentPrimitiveWrappingStructure c,
+                 uint32_t *d,
+                 TransparentIntStruct e,
+                 int32_t f,
+                 DummyStruct g,
+                 uint32_t *h,
+                 int32_t i,
+                 TransparentIntStruct j,
+                 TransparentComplexStruct k,
+                 TransparentTransparentStruct l,
+                 TransparentNonNullStruct m,
+                 TransparentOptionNonNullStruct n);
 
 }  // extern "C"

--- a/tests/expectations/transparent.pyx
+++ b/tests/expectations/transparent.pyx
@@ -12,6 +12,9 @@ cdef extern from *:
   ctypedef struct EnumWithAssociatedConstantInImpl:
     pass
 
+  ctypedef struct StructWithAssociatedConstantInImpl:
+    pass
+
   ctypedef DummyStruct TransparentComplexWrappingStructTuple;
 
   ctypedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -31,7 +34,21 @@ cdef extern from *:
   ctypedef struct TransparentEmptyStructure:
     pass
 
-  const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_TEN # = 10
+  ctypedef const uint32_t *TransparentPointerWrappingStructure;
+
+  ctypedef int32_t TransparentIntStruct;
+
+  ctypedef DummyStruct TransparentComplexStruct;
+
+  ctypedef TransparentPrimitiveWrappingStructure TransparentTransparentStruct;
+
+  ctypedef uint32_t *TransparentNonNullStruct;
+
+  ctypedef uint32_t *TransparentOptionNonNullStruct;
+
+  const TransparentPrimitiveWrappingStructure StructWithAssociatedConstantInImpl_STRUCT_TEN # = 10
+
+  const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_ENUM_TEN # = 10
 
   void root(TransparentComplexWrappingStructTuple a,
             TransparentPrimitiveWrappingStructTuple b,
@@ -41,4 +58,21 @@ cdef extern from *:
             TransparentPrimitiveWrapper_i32 f,
             TransparentPrimitiveWithAssociatedConstants g,
             TransparentEmptyStructure h,
-            EnumWithAssociatedConstantInImpl i);
+            TransparentPointerWrappingStructure i,
+            StructWithAssociatedConstantInImpl j,
+            EnumWithAssociatedConstantInImpl k);
+
+  void erased_root(uint32_t *a,
+                   uint32_t *b,
+                   TransparentPrimitiveWrappingStructure c,
+                   uint32_t *d,
+                   TransparentIntStruct e,
+                   int32_t f,
+                   DummyStruct g,
+                   uint32_t *h,
+                   int32_t i,
+                   TransparentIntStruct j,
+                   TransparentComplexStruct k,
+                   TransparentTransparentStruct l,
+                   TransparentNonNullStruct m,
+                   TransparentOptionNonNullStruct n);

--- a/tests/expectations/transparent_both.c
+++ b/tests/expectations/transparent_both.c
@@ -7,6 +7,8 @@ typedef struct DummyStruct DummyStruct;
 
 typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
 
+typedef struct StructWithAssociatedConstantInImpl StructWithAssociatedConstantInImpl;
+
 typedef struct DummyStruct TransparentComplexWrappingStructTuple;
 
 typedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -27,7 +29,21 @@ typedef struct TransparentEmptyStructure {
 
 } TransparentEmptyStructure;
 
-#define EnumWithAssociatedConstantInImpl_TEN 10
+typedef const uint32_t *TransparentPointerWrappingStructure;
+
+typedef int32_t TransparentIntStruct;
+
+typedef struct DummyStruct TransparentComplexStruct;
+
+typedef TransparentPrimitiveWrappingStructure TransparentTransparentStruct;
+
+typedef uint32_t *TransparentNonNullStruct;
+
+typedef uint32_t *TransparentOptionNonNullStruct;
+
+#define StructWithAssociatedConstantInImpl_STRUCT_TEN 10
+
+#define EnumWithAssociatedConstantInImpl_ENUM_TEN 10
 
 void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructTuple b,
@@ -37,4 +53,21 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
           struct TransparentEmptyStructure h,
-          struct EnumWithAssociatedConstantInImpl i);
+          TransparentPointerWrappingStructure i,
+          struct StructWithAssociatedConstantInImpl j,
+          struct EnumWithAssociatedConstantInImpl k);
+
+void erased_root(uint32_t *a,
+                 uint32_t *b,
+                 TransparentPrimitiveWrappingStructure c,
+                 uint32_t *d,
+                 TransparentIntStruct e,
+                 int32_t f,
+                 struct DummyStruct g,
+                 uint32_t *h,
+                 int32_t i,
+                 TransparentIntStruct j,
+                 TransparentComplexStruct k,
+                 TransparentTransparentStruct l,
+                 TransparentNonNullStruct m,
+                 TransparentOptionNonNullStruct n);

--- a/tests/expectations/transparent_both.compat.c
+++ b/tests/expectations/transparent_both.compat.c
@@ -7,6 +7,8 @@ typedef struct DummyStruct DummyStruct;
 
 typedef struct EnumWithAssociatedConstantInImpl EnumWithAssociatedConstantInImpl;
 
+typedef struct StructWithAssociatedConstantInImpl StructWithAssociatedConstantInImpl;
+
 typedef struct DummyStruct TransparentComplexWrappingStructTuple;
 
 typedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -27,7 +29,21 @@ typedef struct TransparentEmptyStructure {
 
 } TransparentEmptyStructure;
 
-#define EnumWithAssociatedConstantInImpl_TEN 10
+typedef const uint32_t *TransparentPointerWrappingStructure;
+
+typedef int32_t TransparentIntStruct;
+
+typedef struct DummyStruct TransparentComplexStruct;
+
+typedef TransparentPrimitiveWrappingStructure TransparentTransparentStruct;
+
+typedef uint32_t *TransparentNonNullStruct;
+
+typedef uint32_t *TransparentOptionNonNullStruct;
+
+#define StructWithAssociatedConstantInImpl_STRUCT_TEN 10
+
+#define EnumWithAssociatedConstantInImpl_ENUM_TEN 10
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,7 +57,24 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
           struct TransparentEmptyStructure h,
-          struct EnumWithAssociatedConstantInImpl i);
+          TransparentPointerWrappingStructure i,
+          struct StructWithAssociatedConstantInImpl j,
+          struct EnumWithAssociatedConstantInImpl k);
+
+void erased_root(uint32_t *a,
+                 uint32_t *b,
+                 TransparentPrimitiveWrappingStructure c,
+                 uint32_t *d,
+                 TransparentIntStruct e,
+                 int32_t f,
+                 struct DummyStruct g,
+                 uint32_t *h,
+                 int32_t i,
+                 TransparentIntStruct j,
+                 TransparentComplexStruct k,
+                 TransparentTransparentStruct l,
+                 TransparentNonNullStruct m,
+                 TransparentOptionNonNullStruct n);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/transparent_tag.c
+++ b/tests/expectations/transparent_tag.c
@@ -7,6 +7,8 @@ struct DummyStruct;
 
 struct EnumWithAssociatedConstantInImpl;
 
+struct StructWithAssociatedConstantInImpl;
+
 typedef struct DummyStruct TransparentComplexWrappingStructTuple;
 
 typedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -27,7 +29,21 @@ struct TransparentEmptyStructure {
 
 };
 
-#define EnumWithAssociatedConstantInImpl_TEN 10
+typedef const uint32_t *TransparentPointerWrappingStructure;
+
+typedef int32_t TransparentIntStruct;
+
+typedef struct DummyStruct TransparentComplexStruct;
+
+typedef TransparentPrimitiveWrappingStructure TransparentTransparentStruct;
+
+typedef uint32_t *TransparentNonNullStruct;
+
+typedef uint32_t *TransparentOptionNonNullStruct;
+
+#define StructWithAssociatedConstantInImpl_STRUCT_TEN 10
+
+#define EnumWithAssociatedConstantInImpl_ENUM_TEN 10
 
 void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrappingStructTuple b,
@@ -37,4 +53,21 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
           struct TransparentEmptyStructure h,
-          struct EnumWithAssociatedConstantInImpl i);
+          TransparentPointerWrappingStructure i,
+          struct StructWithAssociatedConstantInImpl j,
+          struct EnumWithAssociatedConstantInImpl k);
+
+void erased_root(uint32_t *a,
+                 uint32_t *b,
+                 TransparentPrimitiveWrappingStructure c,
+                 uint32_t *d,
+                 TransparentIntStruct e,
+                 int32_t f,
+                 struct DummyStruct g,
+                 uint32_t *h,
+                 int32_t i,
+                 TransparentIntStruct j,
+                 TransparentComplexStruct k,
+                 TransparentTransparentStruct l,
+                 TransparentNonNullStruct m,
+                 TransparentOptionNonNullStruct n);

--- a/tests/expectations/transparent_tag.compat.c
+++ b/tests/expectations/transparent_tag.compat.c
@@ -7,6 +7,8 @@ struct DummyStruct;
 
 struct EnumWithAssociatedConstantInImpl;
 
+struct StructWithAssociatedConstantInImpl;
+
 typedef struct DummyStruct TransparentComplexWrappingStructTuple;
 
 typedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -27,7 +29,21 @@ struct TransparentEmptyStructure {
 
 };
 
-#define EnumWithAssociatedConstantInImpl_TEN 10
+typedef const uint32_t *TransparentPointerWrappingStructure;
+
+typedef int32_t TransparentIntStruct;
+
+typedef struct DummyStruct TransparentComplexStruct;
+
+typedef TransparentPrimitiveWrappingStructure TransparentTransparentStruct;
+
+typedef uint32_t *TransparentNonNullStruct;
+
+typedef uint32_t *TransparentOptionNonNullStruct;
+
+#define StructWithAssociatedConstantInImpl_STRUCT_TEN 10
+
+#define EnumWithAssociatedConstantInImpl_ENUM_TEN 10
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,7 +57,24 @@ void root(TransparentComplexWrappingStructTuple a,
           TransparentPrimitiveWrapper_i32 f,
           TransparentPrimitiveWithAssociatedConstants g,
           struct TransparentEmptyStructure h,
-          struct EnumWithAssociatedConstantInImpl i);
+          TransparentPointerWrappingStructure i,
+          struct StructWithAssociatedConstantInImpl j,
+          struct EnumWithAssociatedConstantInImpl k);
+
+void erased_root(uint32_t *a,
+                 uint32_t *b,
+                 TransparentPrimitiveWrappingStructure c,
+                 uint32_t *d,
+                 TransparentIntStruct e,
+                 int32_t f,
+                 struct DummyStruct g,
+                 uint32_t *h,
+                 int32_t i,
+                 TransparentIntStruct j,
+                 TransparentComplexStruct k,
+                 TransparentTransparentStruct l,
+                 TransparentNonNullStruct m,
+                 TransparentOptionNonNullStruct n);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/tests/expectations/transparent_tag.pyx
+++ b/tests/expectations/transparent_tag.pyx
@@ -12,6 +12,9 @@ cdef extern from *:
   cdef struct EnumWithAssociatedConstantInImpl:
     pass
 
+  cdef struct StructWithAssociatedConstantInImpl:
+    pass
+
   ctypedef DummyStruct TransparentComplexWrappingStructTuple;
 
   ctypedef uint32_t TransparentPrimitiveWrappingStructTuple;
@@ -31,7 +34,21 @@ cdef extern from *:
   cdef struct TransparentEmptyStructure:
     pass
 
-  const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_TEN # = 10
+  ctypedef const uint32_t *TransparentPointerWrappingStructure;
+
+  ctypedef int32_t TransparentIntStruct;
+
+  ctypedef DummyStruct TransparentComplexStruct;
+
+  ctypedef TransparentPrimitiveWrappingStructure TransparentTransparentStruct;
+
+  ctypedef uint32_t *TransparentNonNullStruct;
+
+  ctypedef uint32_t *TransparentOptionNonNullStruct;
+
+  const TransparentPrimitiveWrappingStructure StructWithAssociatedConstantInImpl_STRUCT_TEN # = 10
+
+  const TransparentPrimitiveWrappingStructure EnumWithAssociatedConstantInImpl_ENUM_TEN # = 10
 
   void root(TransparentComplexWrappingStructTuple a,
             TransparentPrimitiveWrappingStructTuple b,
@@ -41,4 +58,21 @@ cdef extern from *:
             TransparentPrimitiveWrapper_i32 f,
             TransparentPrimitiveWithAssociatedConstants g,
             TransparentEmptyStructure h,
-            EnumWithAssociatedConstantInImpl i);
+            TransparentPointerWrappingStructure i,
+            StructWithAssociatedConstantInImpl j,
+            EnumWithAssociatedConstantInImpl k);
+
+  void erased_root(uint32_t *a,
+                   uint32_t *b,
+                   TransparentPrimitiveWrappingStructure c,
+                   uint32_t *d,
+                   TransparentIntStruct e,
+                   int32_t f,
+                   DummyStruct g,
+                   uint32_t *h,
+                   int32_t i,
+                   TransparentIntStruct j,
+                   TransparentComplexStruct k,
+                   TransparentTransparentStruct l,
+                   TransparentNonNullStruct m,
+                   TransparentOptionNonNullStruct n);

--- a/tests/expectations/transparent_typedef.c
+++ b/tests/expectations/transparent_typedef.c
@@ -1,0 +1,229 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque_i32 Opaque_i32;
+
+typedef struct Option_Option_Struct_Option_i32 Option_Option_Struct_Option_i32;
+
+typedef struct Option_Option_i32 Option_Option_i32;
+
+typedef struct Option_Struct_Option_i32 Option_Struct_Option_i32;
+
+typedef struct Option_Struct_Struct_Option_i32 Option_Struct_Struct_Option_i32;
+
+typedef struct Option_Struct_i32 Option_Struct_i32;
+
+typedef struct Option_i32 Option_i32;
+
+typedef struct {
+  int32_t a;
+  int32_t *n;
+  int32_t t;
+  int32_t (*f)(int32_t a, int32_t *n);
+  int32_t ai;
+  int32_t *ni;
+  int32_t ti;
+  int32_t (*fi)(int32_t ai, int32_t *ni);
+} FullyTransparent1_i32;
+
+typedef struct {
+  const Option_i32 *field;
+} Struct_Option_i32;
+
+typedef Option_i32 Typedef_Option_i32;
+
+typedef struct {
+  const int32_t *field;
+} Struct_i32;
+
+typedef int32_t Typedef_i32;
+
+typedef struct {
+  const Option_Option_i32 *o;
+  const Struct_Option_i32 *s;
+  const Typedef_Option_i32 *t;
+  Typedef_Option_i32 *(*f)(const Option_Option_i32 *o, const Struct_Option_i32 *s);
+  const Option_i32 *oi;
+  const Struct_i32 *si;
+  const Typedef_i32 *ti;
+  Typedef_i32 *(*fi)(const Option_i32 *oi, const Struct_i32 *si);
+} NotTransparent1_Option_i32;
+
+typedef struct {
+  int32_t aa;
+  int32_t *an;
+  int32_t at;
+  int32_t *na;
+  int32_t **nn;
+  int32_t *nt;
+  int32_t *on;
+  int32_t ta;
+  int32_t *tn;
+  int32_t tt;
+  int32_t (*f)(int32_t aa,
+               int32_t *an,
+               int32_t at,
+               int32_t *na,
+               int32_t **nn,
+               int32_t *nt,
+               int32_t *on,
+               int32_t ta,
+               int32_t *tn);
+  int32_t aai;
+  int32_t *ani;
+  int32_t ati;
+  int32_t *nai;
+  int32_t **nni;
+  int32_t *nti;
+  int32_t *oni;
+  int32_t tai;
+  int32_t *tni;
+  int32_t tti;
+  int32_t (*fi)(int32_t aai,
+                int32_t *ani,
+                int32_t ati,
+                int32_t *nai,
+                int32_t **nni,
+                int32_t *nti,
+                int32_t *oni,
+                int32_t tai,
+                int32_t *tni);
+} FullyTransparent2_i32;
+
+typedef struct {
+  const Option_Option_i32 *ao;
+  const Struct_Option_i32 *aS;
+  const Typedef_Option_i32 *at;
+  Option_Option_i32 *const *no;
+  Struct_Option_i32 *const *ns;
+  Typedef_Option_i32 *const *nt;
+  Typedef_Option_i32 **(*f)(const Option_Option_i32 *ao,
+                            const Struct_Option_i32 *aS,
+                            const Typedef_Option_i32 *at,
+                            Option_Option_i32 *const *no,
+                            Struct_Option_i32 *const *ns);
+  const Option_i32 *aoi;
+  const Struct_i32 *asi;
+  const Typedef_i32 *ati;
+  Option_i32 *const *noi;
+  Struct_i32 *const *nsi;
+  Typedef_i32 *const *nti;
+  Typedef_i32 **(*fi)(const Option_i32 *aoi,
+                      const Struct_i32 *asi,
+                      const Typedef_i32 *ati,
+                      Option_i32 *const *noi,
+                      Struct_i32 *const *nsi);
+} PartlyTransparent2_Option_i32;
+
+typedef struct {
+  const Option_Struct_Option_i32 *field;
+} Struct_Option_Struct_Option_i32;
+
+typedef struct {
+  const Struct_Option_i32 *field;
+} Struct_Struct_Option_i32;
+
+typedef struct {
+  const Struct_Struct_Option_i32 *field;
+} Struct_Struct_Struct_Option_i32;
+
+typedef struct {
+  const Struct_i32 *field;
+} Struct_Struct_i32;
+
+typedef struct {
+  const Option_Option_Struct_Option_i32 *oo;
+  const Option_Struct_Struct_Option_i32 *os;
+  const Struct_Option_Struct_Option_i32 *so;
+  const Struct_Struct_Struct_Option_i32 *ss;
+  Struct_Struct_Struct_Option_i32 *(*f)(const Option_Option_Struct_Option_i32 *oo,
+                                        const Option_Struct_Struct_Option_i32 *os,
+                                        const Struct_Option_Struct_Option_i32 *so);
+  const Option_Option_i32 *ooi;
+  const Option_Struct_i32 *osi;
+  const Struct_Option_i32 *soi;
+  const Struct_Struct_i32 *ssi;
+  Struct_Struct_i32 *(*fi)(const Option_Option_i32 *ooi,
+                           const Option_Struct_i32 *osi,
+                           const Struct_Option_i32 *soi);
+} NotTransparent2_Struct_Option_i32;
+
+typedef enum {
+  ont_____i32,
+  otn_____i32,
+  ton_____i32,
+  totn_____i32,
+  f_____i32,
+  onti_____i32,
+  otni_____i32,
+  toni_____i32,
+  totni_____i32,
+  fi_____i32,
+} FullyTransparentMany_____i32_Tag;
+
+typedef struct {
+  FullyTransparentMany_____i32_Tag tag;
+  union {
+    struct {
+      int32_t **ont;
+    };
+    struct {
+      int32_t **otn;
+    };
+    struct {
+      int32_t **ton;
+    };
+    struct {
+      int32_t **totn;
+    };
+    struct {
+      int32_t **(*f)(int32_t **ont, int32_t **otn, int32_t **ton);
+    };
+    struct {
+      int32_t *onti;
+    };
+    struct {
+      int32_t *otni;
+    };
+    struct {
+      int32_t *toni;
+    };
+    struct {
+      int32_t *totni;
+    };
+    struct {
+      int32_t *(*fi)(int32_t *onti, int32_t *otni, int32_t *toni);
+    };
+  };
+} FullyTransparentMany_____i32;
+
+typedef union {
+  const Option_Option_i32 *tao;
+  const Option_Option_i32 *toa;
+  const Option_Option_i32 *ota;
+  const Struct_Option_i32 *tas;
+  const Struct_Option_i32 *tsa;
+  const Struct_Option_i32 *sta;
+  const Option_Option_i32 *toat;
+  const Struct_Option_i32 *tsat;
+  const Option_i32 *taoi;
+  const Option_i32 *toai;
+  const Option_i32 *otai;
+  const Struct_i32 *tasi;
+  const Struct_i32 *tsai;
+  const Struct_i32 *stai;
+  const Option_i32 *toati;
+  const Struct_i32 *tsati;
+} PartlyTransparentMany_Option_i32;
+
+void root_opaque(const Opaque_i32 *o);
+
+void root1(FullyTransparent1_i32 a, NotTransparent1_Option_i32 s);
+
+void root2(FullyTransparent2_i32 a,
+           PartlyTransparent2_Option_i32 s,
+           NotTransparent2_Struct_Option_i32 n);
+
+void root_many(FullyTransparentMany_____i32 a, PartlyTransparentMany_Option_i32 b);

--- a/tests/expectations/transparent_typedef.compat.c
+++ b/tests/expectations/transparent_typedef.compat.c
@@ -1,0 +1,237 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque_i32 Opaque_i32;
+
+typedef struct Option_Option_Struct_Option_i32 Option_Option_Struct_Option_i32;
+
+typedef struct Option_Option_i32 Option_Option_i32;
+
+typedef struct Option_Struct_Option_i32 Option_Struct_Option_i32;
+
+typedef struct Option_Struct_Struct_Option_i32 Option_Struct_Struct_Option_i32;
+
+typedef struct Option_Struct_i32 Option_Struct_i32;
+
+typedef struct Option_i32 Option_i32;
+
+typedef struct {
+  int32_t a;
+  int32_t *n;
+  int32_t t;
+  int32_t (*f)(int32_t a, int32_t *n);
+  int32_t ai;
+  int32_t *ni;
+  int32_t ti;
+  int32_t (*fi)(int32_t ai, int32_t *ni);
+} FullyTransparent1_i32;
+
+typedef struct {
+  const Option_i32 *field;
+} Struct_Option_i32;
+
+typedef Option_i32 Typedef_Option_i32;
+
+typedef struct {
+  const int32_t *field;
+} Struct_i32;
+
+typedef int32_t Typedef_i32;
+
+typedef struct {
+  const Option_Option_i32 *o;
+  const Struct_Option_i32 *s;
+  const Typedef_Option_i32 *t;
+  Typedef_Option_i32 *(*f)(const Option_Option_i32 *o, const Struct_Option_i32 *s);
+  const Option_i32 *oi;
+  const Struct_i32 *si;
+  const Typedef_i32 *ti;
+  Typedef_i32 *(*fi)(const Option_i32 *oi, const Struct_i32 *si);
+} NotTransparent1_Option_i32;
+
+typedef struct {
+  int32_t aa;
+  int32_t *an;
+  int32_t at;
+  int32_t *na;
+  int32_t **nn;
+  int32_t *nt;
+  int32_t *on;
+  int32_t ta;
+  int32_t *tn;
+  int32_t tt;
+  int32_t (*f)(int32_t aa,
+               int32_t *an,
+               int32_t at,
+               int32_t *na,
+               int32_t **nn,
+               int32_t *nt,
+               int32_t *on,
+               int32_t ta,
+               int32_t *tn);
+  int32_t aai;
+  int32_t *ani;
+  int32_t ati;
+  int32_t *nai;
+  int32_t **nni;
+  int32_t *nti;
+  int32_t *oni;
+  int32_t tai;
+  int32_t *tni;
+  int32_t tti;
+  int32_t (*fi)(int32_t aai,
+                int32_t *ani,
+                int32_t ati,
+                int32_t *nai,
+                int32_t **nni,
+                int32_t *nti,
+                int32_t *oni,
+                int32_t tai,
+                int32_t *tni);
+} FullyTransparent2_i32;
+
+typedef struct {
+  const Option_Option_i32 *ao;
+  const Struct_Option_i32 *aS;
+  const Typedef_Option_i32 *at;
+  Option_Option_i32 *const *no;
+  Struct_Option_i32 *const *ns;
+  Typedef_Option_i32 *const *nt;
+  Typedef_Option_i32 **(*f)(const Option_Option_i32 *ao,
+                            const Struct_Option_i32 *aS,
+                            const Typedef_Option_i32 *at,
+                            Option_Option_i32 *const *no,
+                            Struct_Option_i32 *const *ns);
+  const Option_i32 *aoi;
+  const Struct_i32 *asi;
+  const Typedef_i32 *ati;
+  Option_i32 *const *noi;
+  Struct_i32 *const *nsi;
+  Typedef_i32 *const *nti;
+  Typedef_i32 **(*fi)(const Option_i32 *aoi,
+                      const Struct_i32 *asi,
+                      const Typedef_i32 *ati,
+                      Option_i32 *const *noi,
+                      Struct_i32 *const *nsi);
+} PartlyTransparent2_Option_i32;
+
+typedef struct {
+  const Option_Struct_Option_i32 *field;
+} Struct_Option_Struct_Option_i32;
+
+typedef struct {
+  const Struct_Option_i32 *field;
+} Struct_Struct_Option_i32;
+
+typedef struct {
+  const Struct_Struct_Option_i32 *field;
+} Struct_Struct_Struct_Option_i32;
+
+typedef struct {
+  const Struct_i32 *field;
+} Struct_Struct_i32;
+
+typedef struct {
+  const Option_Option_Struct_Option_i32 *oo;
+  const Option_Struct_Struct_Option_i32 *os;
+  const Struct_Option_Struct_Option_i32 *so;
+  const Struct_Struct_Struct_Option_i32 *ss;
+  Struct_Struct_Struct_Option_i32 *(*f)(const Option_Option_Struct_Option_i32 *oo,
+                                        const Option_Struct_Struct_Option_i32 *os,
+                                        const Struct_Option_Struct_Option_i32 *so);
+  const Option_Option_i32 *ooi;
+  const Option_Struct_i32 *osi;
+  const Struct_Option_i32 *soi;
+  const Struct_Struct_i32 *ssi;
+  Struct_Struct_i32 *(*fi)(const Option_Option_i32 *ooi,
+                           const Option_Struct_i32 *osi,
+                           const Struct_Option_i32 *soi);
+} NotTransparent2_Struct_Option_i32;
+
+typedef enum {
+  ont_____i32,
+  otn_____i32,
+  ton_____i32,
+  totn_____i32,
+  f_____i32,
+  onti_____i32,
+  otni_____i32,
+  toni_____i32,
+  totni_____i32,
+  fi_____i32,
+} FullyTransparentMany_____i32_Tag;
+
+typedef struct {
+  FullyTransparentMany_____i32_Tag tag;
+  union {
+    struct {
+      int32_t **ont;
+    };
+    struct {
+      int32_t **otn;
+    };
+    struct {
+      int32_t **ton;
+    };
+    struct {
+      int32_t **totn;
+    };
+    struct {
+      int32_t **(*f)(int32_t **ont, int32_t **otn, int32_t **ton);
+    };
+    struct {
+      int32_t *onti;
+    };
+    struct {
+      int32_t *otni;
+    };
+    struct {
+      int32_t *toni;
+    };
+    struct {
+      int32_t *totni;
+    };
+    struct {
+      int32_t *(*fi)(int32_t *onti, int32_t *otni, int32_t *toni);
+    };
+  };
+} FullyTransparentMany_____i32;
+
+typedef union {
+  const Option_Option_i32 *tao;
+  const Option_Option_i32 *toa;
+  const Option_Option_i32 *ota;
+  const Struct_Option_i32 *tas;
+  const Struct_Option_i32 *tsa;
+  const Struct_Option_i32 *sta;
+  const Option_Option_i32 *toat;
+  const Struct_Option_i32 *tsat;
+  const Option_i32 *taoi;
+  const Option_i32 *toai;
+  const Option_i32 *otai;
+  const Struct_i32 *tasi;
+  const Struct_i32 *tsai;
+  const Struct_i32 *stai;
+  const Option_i32 *toati;
+  const Struct_i32 *tsati;
+} PartlyTransparentMany_Option_i32;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root_opaque(const Opaque_i32 *o);
+
+void root1(FullyTransparent1_i32 a, NotTransparent1_Option_i32 s);
+
+void root2(FullyTransparent2_i32 a,
+           PartlyTransparent2_Option_i32 s,
+           NotTransparent2_Struct_Option_i32 n);
+
+void root_many(FullyTransparentMany_____i32 a, PartlyTransparentMany_Option_i32 b);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tests/expectations/transparent_typedef.cpp
+++ b/tests/expectations/transparent_typedef.cpp
@@ -1,0 +1,225 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+template<typename U = int32_t>
+struct Opaque;
+
+template<typename T = void>
+struct Option;
+
+template<typename E = int64_t>
+struct FullyTransparent1 {
+  E a;
+  E *n;
+  E t;
+  E (*f)(E a, E *n);
+  int32_t ai;
+  int32_t *ni;
+  int32_t ti;
+  int32_t (*fi)(int32_t ai, int32_t *ni);
+};
+
+template<typename U, typename P = U>
+struct Struct {
+  const U *field;
+};
+
+template<typename U = int64_t>
+using Typedef = U;
+
+template<typename E = Option<int64_t>>
+struct NotTransparent1 {
+  const Option<E> *o;
+  const Struct<E> *s;
+  const Typedef<E> *t;
+  Typedef<E> *(*f)(const Option<E> *o, const Struct<E> *s);
+  const Option<int32_t> *oi;
+  const Struct<int32_t> *si;
+  const Typedef<int32_t> *ti;
+  Typedef<int32_t> *(*fi)(const Option<int32_t> *oi, const Struct<int32_t> *si);
+};
+
+template<typename E = int32_t>
+struct FullyTransparent2 {
+  E aa;
+  E *an;
+  E at;
+  E *na;
+  E **nn;
+  E *nt;
+  E *on;
+  E ta;
+  E *tn;
+  E tt;
+  E (*f)(E aa, E *an, E at, E *na, E **nn, E *nt, E *on, E ta, E *tn);
+  int32_t aai;
+  int32_t *ani;
+  int32_t ati;
+  int32_t *nai;
+  int32_t **nni;
+  int32_t *nti;
+  int32_t *oni;
+  int32_t tai;
+  int32_t *tni;
+  int32_t tti;
+  int32_t (*fi)(int32_t aai,
+                int32_t *ani,
+                int32_t ati,
+                int32_t *nai,
+                int32_t **nni,
+                int32_t *nti,
+                int32_t *oni,
+                int32_t tai,
+                int32_t *tni);
+};
+
+template<typename E = Option<int64_t>>
+struct PartlyTransparent2 {
+  const Option<E> *ao;
+  const Struct<E> *aS;
+  const Typedef<E> *at;
+  Option<E> *const *no;
+  Struct<E> *const *ns;
+  Typedef<E> *const *nt;
+  Typedef<E> **(*f)(const Option<E> *ao,
+                    const Struct<E> *aS,
+                    const Typedef<E> *at,
+                    Option<E> *const *no,
+                    Struct<E> *const *ns);
+  const Option<int32_t> *aoi;
+  const Struct<int32_t> *asi;
+  const Typedef<int32_t> *ati;
+  Option<int32_t> *const *noi;
+  Struct<int32_t> *const *nsi;
+  Typedef<int32_t> *const *nti;
+  Typedef<int32_t> **(*fi)(const Option<int32_t> *aoi,
+                           const Struct<int32_t> *asi,
+                           const Typedef<int32_t> *ati,
+                           Option<int32_t> *const *noi,
+                           Struct<int32_t> *const *nsi);
+};
+
+template<typename E = Option<Struct<int64_t>>>
+struct NotTransparent2 {
+  const Option<Option<E>> *oo;
+  const Option<Struct<E>> *os;
+  const Struct<Option<E>> *so;
+  const Struct<Struct<E>> *ss;
+  Struct<Struct<E>> *(*f)(const Option<Option<E>> *oo,
+                          const Option<Struct<E>> *os,
+                          const Struct<Option<E>> *so);
+  const Option<Option<int32_t>> *ooi;
+  const Option<Struct<int32_t>> *osi;
+  const Struct<Option<int32_t>> *soi;
+  const Struct<Struct<int32_t>> *ssi;
+  Struct<Struct<int32_t>> *(*fi)(const Option<Option<int32_t>> *ooi,
+                                 const Option<Struct<int32_t>> *osi,
+                                 const Struct<Option<int32_t>> *soi);
+};
+
+template<typename E = int64_t*>
+struct FullyTransparentMany {
+  enum class Tag {
+    ont,
+    otn,
+    ton,
+    totn,
+    f,
+    onti,
+    otni,
+    toni,
+    totni,
+    fi,
+  };
+
+  struct ont_Body {
+    E *_0;
+  };
+
+  struct otn_Body {
+    E *_0;
+  };
+
+  struct ton_Body {
+    E *_0;
+  };
+
+  struct totn_Body {
+    E *_0;
+  };
+
+  struct f_Body {
+    E *(*_0)(E *ont, E *otn, E *ton);
+  };
+
+  struct onti_Body {
+    int32_t *_0;
+  };
+
+  struct otni_Body {
+    int32_t *_0;
+  };
+
+  struct toni_Body {
+    int32_t *_0;
+  };
+
+  struct totni_Body {
+    int32_t *_0;
+  };
+
+  struct fi_Body {
+    int32_t *(*_0)(int32_t *onti, int32_t *otni, int32_t *toni);
+  };
+
+  Tag tag;
+  union {
+    ont_Body ont;
+    otn_Body otn;
+    ton_Body ton;
+    totn_Body totn;
+    f_Body f;
+    onti_Body onti;
+    otni_Body otni;
+    toni_Body toni;
+    totni_Body totni;
+    fi_Body fi;
+  };
+};
+
+template<typename E = Option<int64_t>>
+union PartlyTransparentMany {
+  const Option<E> *tao;
+  const Option<E> *toa;
+  const Option<E> *ota;
+  const Struct<E> *tas;
+  const Struct<E> *tsa;
+  const Struct<E> *sta;
+  const Option<E> *toat;
+  const Struct<E> *tsat;
+  const Option<int32_t> *taoi;
+  const Option<int32_t> *toai;
+  const Option<int32_t> *otai;
+  const Struct<int32_t> *tasi;
+  const Struct<int32_t> *tsai;
+  const Struct<int32_t> *stai;
+  const Option<int32_t> *toati;
+  const Struct<int32_t> *tsati;
+};
+
+extern "C" {
+
+void root_opaque(const Opaque<int32_t> *o);
+
+void root1(FullyTransparent1<int32_t> a, NotTransparent1<Option<int32_t>> s);
+
+void root2(FullyTransparent2<int32_t> a,
+           PartlyTransparent2<Option<int32_t>> s,
+           NotTransparent2<Struct<Option<int32_t>>> n);
+
+void root_many(FullyTransparentMany<int32_t*> a, PartlyTransparentMany<Option<int32_t>> b);
+
+}  // extern "C"

--- a/tests/expectations/transparent_typedef.pyx
+++ b/tests/expectations/transparent_typedef.pyx
@@ -1,0 +1,203 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef struct Opaque_i32:
+    pass
+
+  ctypedef struct Option_Option_Struct_Option_i32:
+    pass
+
+  ctypedef struct Option_Option_i32:
+    pass
+
+  ctypedef struct Option_Struct_Option_i32:
+    pass
+
+  ctypedef struct Option_Struct_Struct_Option_i32:
+    pass
+
+  ctypedef struct Option_Struct_i32:
+    pass
+
+  ctypedef struct Option_i32:
+    pass
+
+  ctypedef struct FullyTransparent1_i32:
+    int32_t a;
+    int32_t *n;
+    int32_t t;
+    int32_t (*f)(int32_t a, int32_t *n);
+    int32_t ai;
+    int32_t *ni;
+    int32_t ti;
+    int32_t (*fi)(int32_t ai, int32_t *ni);
+
+  ctypedef struct Struct_Option_i32:
+    const Option_i32 *field;
+
+  ctypedef Option_i32 Typedef_Option_i32;
+
+  ctypedef struct Struct_i32:
+    const int32_t *field;
+
+  ctypedef int32_t Typedef_i32;
+
+  ctypedef struct NotTransparent1_Option_i32:
+    const Option_Option_i32 *o;
+    const Struct_Option_i32 *s;
+    const Typedef_Option_i32 *t;
+    Typedef_Option_i32 *(*f)(const Option_Option_i32 *o, const Struct_Option_i32 *s);
+    const Option_i32 *oi;
+    const Struct_i32 *si;
+    const Typedef_i32 *ti;
+    Typedef_i32 *(*fi)(const Option_i32 *oi, const Struct_i32 *si);
+
+  ctypedef struct FullyTransparent2_i32:
+    int32_t aa;
+    int32_t *an;
+    int32_t at;
+    int32_t *na;
+    int32_t **nn;
+    int32_t *nt;
+    int32_t *on;
+    int32_t ta;
+    int32_t *tn;
+    int32_t tt;
+    int32_t (*f)(int32_t aa,
+                 int32_t *an,
+                 int32_t at,
+                 int32_t *na,
+                 int32_t **nn,
+                 int32_t *nt,
+                 int32_t *on,
+                 int32_t ta,
+                 int32_t *tn);
+    int32_t aai;
+    int32_t *ani;
+    int32_t ati;
+    int32_t *nai;
+    int32_t **nni;
+    int32_t *nti;
+    int32_t *oni;
+    int32_t tai;
+    int32_t *tni;
+    int32_t tti;
+    int32_t (*fi)(int32_t aai,
+                  int32_t *ani,
+                  int32_t ati,
+                  int32_t *nai,
+                  int32_t **nni,
+                  int32_t *nti,
+                  int32_t *oni,
+                  int32_t tai,
+                  int32_t *tni);
+
+  ctypedef struct PartlyTransparent2_Option_i32:
+    const Option_Option_i32 *ao;
+    const Struct_Option_i32 *aS;
+    const Typedef_Option_i32 *at;
+    Option_Option_i32 *const *no;
+    Struct_Option_i32 *const *ns;
+    Typedef_Option_i32 *const *nt;
+    Typedef_Option_i32 **(*f)(const Option_Option_i32 *ao,
+                              const Struct_Option_i32 *aS,
+                              const Typedef_Option_i32 *at,
+                              Option_Option_i32 *const *no,
+                              Struct_Option_i32 *const *ns);
+    const Option_i32 *aoi;
+    const Struct_i32 *asi;
+    const Typedef_i32 *ati;
+    Option_i32 *const *noi;
+    Struct_i32 *const *nsi;
+    Typedef_i32 *const *nti;
+    Typedef_i32 **(*fi)(const Option_i32 *aoi,
+                        const Struct_i32 *asi,
+                        const Typedef_i32 *ati,
+                        Option_i32 *const *noi,
+                        Struct_i32 *const *nsi);
+
+  ctypedef struct Struct_Option_Struct_Option_i32:
+    const Option_Struct_Option_i32 *field;
+
+  ctypedef struct Struct_Struct_Option_i32:
+    const Struct_Option_i32 *field;
+
+  ctypedef struct Struct_Struct_Struct_Option_i32:
+    const Struct_Struct_Option_i32 *field;
+
+  ctypedef struct Struct_Struct_i32:
+    const Struct_i32 *field;
+
+  ctypedef struct NotTransparent2_Struct_Option_i32:
+    const Option_Option_Struct_Option_i32 *oo;
+    const Option_Struct_Struct_Option_i32 *os;
+    const Struct_Option_Struct_Option_i32 *so;
+    const Struct_Struct_Struct_Option_i32 *ss;
+    Struct_Struct_Struct_Option_i32 *(*f)(const Option_Option_Struct_Option_i32 *oo,
+                                          const Option_Struct_Struct_Option_i32 *os,
+                                          const Struct_Option_Struct_Option_i32 *so);
+    const Option_Option_i32 *ooi;
+    const Option_Struct_i32 *osi;
+    const Struct_Option_i32 *soi;
+    const Struct_Struct_i32 *ssi;
+    Struct_Struct_i32 *(*fi)(const Option_Option_i32 *ooi,
+                             const Option_Struct_i32 *osi,
+                             const Struct_Option_i32 *soi);
+
+  ctypedef enum FullyTransparentMany_____i32_Tag:
+    ont_____i32,
+    otn_____i32,
+    ton_____i32,
+    totn_____i32,
+    f_____i32,
+    onti_____i32,
+    otni_____i32,
+    toni_____i32,
+    totni_____i32,
+    fi_____i32,
+
+  ctypedef struct FullyTransparentMany_____i32:
+    FullyTransparentMany_____i32_Tag tag;
+    int32_t **ont;
+    int32_t **otn;
+    int32_t **ton;
+    int32_t **totn;
+    int32_t **(*f)(int32_t **ont, int32_t **otn, int32_t **ton);
+    int32_t *onti;
+    int32_t *otni;
+    int32_t *toni;
+    int32_t *totni;
+    int32_t *(*fi)(int32_t *onti, int32_t *otni, int32_t *toni);
+
+  ctypedef union PartlyTransparentMany_Option_i32:
+    const Option_Option_i32 *tao;
+    const Option_Option_i32 *toa;
+    const Option_Option_i32 *ota;
+    const Struct_Option_i32 *tas;
+    const Struct_Option_i32 *tsa;
+    const Struct_Option_i32 *sta;
+    const Option_Option_i32 *toat;
+    const Struct_Option_i32 *tsat;
+    const Option_i32 *taoi;
+    const Option_i32 *toai;
+    const Option_i32 *otai;
+    const Struct_i32 *tasi;
+    const Struct_i32 *tsai;
+    const Struct_i32 *stai;
+    const Option_i32 *toati;
+    const Struct_i32 *tsati;
+
+  void root_opaque(const Opaque_i32 *o);
+
+  void root1(FullyTransparent1_i32 a, NotTransparent1_Option_i32 s);
+
+  void root2(FullyTransparent2_i32 a,
+             PartlyTransparent2_Option_i32 s,
+             NotTransparent2_Struct_Option_i32 n);
+
+  void root_many(FullyTransparentMany_____i32 a, PartlyTransparentMany_Option_i32 b);

--- a/tests/expectations/transparent_typedef_both.c
+++ b/tests/expectations/transparent_typedef_both.c
@@ -1,0 +1,229 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque_i32 Opaque_i32;
+
+typedef struct Option_Option_Struct_Option_i32 Option_Option_Struct_Option_i32;
+
+typedef struct Option_Option_i32 Option_Option_i32;
+
+typedef struct Option_Struct_Option_i32 Option_Struct_Option_i32;
+
+typedef struct Option_Struct_Struct_Option_i32 Option_Struct_Struct_Option_i32;
+
+typedef struct Option_Struct_i32 Option_Struct_i32;
+
+typedef struct Option_i32 Option_i32;
+
+typedef struct FullyTransparent1_i32 {
+  int32_t a;
+  int32_t *n;
+  int32_t t;
+  int32_t (*f)(int32_t a, int32_t *n);
+  int32_t ai;
+  int32_t *ni;
+  int32_t ti;
+  int32_t (*fi)(int32_t ai, int32_t *ni);
+} FullyTransparent1_i32;
+
+typedef struct Struct_Option_i32 {
+  const struct Option_i32 *field;
+} Struct_Option_i32;
+
+typedef struct Option_i32 Typedef_Option_i32;
+
+typedef struct Struct_i32 {
+  const int32_t *field;
+} Struct_i32;
+
+typedef int32_t Typedef_i32;
+
+typedef struct NotTransparent1_Option_i32 {
+  const struct Option_Option_i32 *o;
+  const struct Struct_Option_i32 *s;
+  const Typedef_Option_i32 *t;
+  Typedef_Option_i32 *(*f)(const struct Option_Option_i32 *o, const struct Struct_Option_i32 *s);
+  const struct Option_i32 *oi;
+  const struct Struct_i32 *si;
+  const Typedef_i32 *ti;
+  Typedef_i32 *(*fi)(const struct Option_i32 *oi, const struct Struct_i32 *si);
+} NotTransparent1_Option_i32;
+
+typedef struct FullyTransparent2_i32 {
+  int32_t aa;
+  int32_t *an;
+  int32_t at;
+  int32_t *na;
+  int32_t **nn;
+  int32_t *nt;
+  int32_t *on;
+  int32_t ta;
+  int32_t *tn;
+  int32_t tt;
+  int32_t (*f)(int32_t aa,
+               int32_t *an,
+               int32_t at,
+               int32_t *na,
+               int32_t **nn,
+               int32_t *nt,
+               int32_t *on,
+               int32_t ta,
+               int32_t *tn);
+  int32_t aai;
+  int32_t *ani;
+  int32_t ati;
+  int32_t *nai;
+  int32_t **nni;
+  int32_t *nti;
+  int32_t *oni;
+  int32_t tai;
+  int32_t *tni;
+  int32_t tti;
+  int32_t (*fi)(int32_t aai,
+                int32_t *ani,
+                int32_t ati,
+                int32_t *nai,
+                int32_t **nni,
+                int32_t *nti,
+                int32_t *oni,
+                int32_t tai,
+                int32_t *tni);
+} FullyTransparent2_i32;
+
+typedef struct PartlyTransparent2_Option_i32 {
+  const struct Option_Option_i32 *ao;
+  const struct Struct_Option_i32 *aS;
+  const Typedef_Option_i32 *at;
+  struct Option_Option_i32 *const *no;
+  struct Struct_Option_i32 *const *ns;
+  Typedef_Option_i32 *const *nt;
+  Typedef_Option_i32 **(*f)(const struct Option_Option_i32 *ao,
+                            const struct Struct_Option_i32 *aS,
+                            const Typedef_Option_i32 *at,
+                            struct Option_Option_i32 *const *no,
+                            struct Struct_Option_i32 *const *ns);
+  const struct Option_i32 *aoi;
+  const struct Struct_i32 *asi;
+  const Typedef_i32 *ati;
+  struct Option_i32 *const *noi;
+  struct Struct_i32 *const *nsi;
+  Typedef_i32 *const *nti;
+  Typedef_i32 **(*fi)(const struct Option_i32 *aoi,
+                      const struct Struct_i32 *asi,
+                      const Typedef_i32 *ati,
+                      struct Option_i32 *const *noi,
+                      struct Struct_i32 *const *nsi);
+} PartlyTransparent2_Option_i32;
+
+typedef struct Struct_Option_Struct_Option_i32 {
+  const struct Option_Struct_Option_i32 *field;
+} Struct_Option_Struct_Option_i32;
+
+typedef struct Struct_Struct_Option_i32 {
+  const struct Struct_Option_i32 *field;
+} Struct_Struct_Option_i32;
+
+typedef struct Struct_Struct_Struct_Option_i32 {
+  const struct Struct_Struct_Option_i32 *field;
+} Struct_Struct_Struct_Option_i32;
+
+typedef struct Struct_Struct_i32 {
+  const struct Struct_i32 *field;
+} Struct_Struct_i32;
+
+typedef struct NotTransparent2_Struct_Option_i32 {
+  const struct Option_Option_Struct_Option_i32 *oo;
+  const struct Option_Struct_Struct_Option_i32 *os;
+  const struct Struct_Option_Struct_Option_i32 *so;
+  const struct Struct_Struct_Struct_Option_i32 *ss;
+  struct Struct_Struct_Struct_Option_i32 *(*f)(const struct Option_Option_Struct_Option_i32 *oo,
+                                               const struct Option_Struct_Struct_Option_i32 *os,
+                                               const struct Struct_Option_Struct_Option_i32 *so);
+  const struct Option_Option_i32 *ooi;
+  const struct Option_Struct_i32 *osi;
+  const struct Struct_Option_i32 *soi;
+  const struct Struct_Struct_i32 *ssi;
+  struct Struct_Struct_i32 *(*fi)(const struct Option_Option_i32 *ooi,
+                                  const struct Option_Struct_i32 *osi,
+                                  const struct Struct_Option_i32 *soi);
+} NotTransparent2_Struct_Option_i32;
+
+typedef enum FullyTransparentMany_____i32_Tag {
+  ont_____i32,
+  otn_____i32,
+  ton_____i32,
+  totn_____i32,
+  f_____i32,
+  onti_____i32,
+  otni_____i32,
+  toni_____i32,
+  totni_____i32,
+  fi_____i32,
+} FullyTransparentMany_____i32_Tag;
+
+typedef struct FullyTransparentMany_____i32 {
+  FullyTransparentMany_____i32_Tag tag;
+  union {
+    struct {
+      int32_t **ont;
+    };
+    struct {
+      int32_t **otn;
+    };
+    struct {
+      int32_t **ton;
+    };
+    struct {
+      int32_t **totn;
+    };
+    struct {
+      int32_t **(*f)(int32_t **ont, int32_t **otn, int32_t **ton);
+    };
+    struct {
+      int32_t *onti;
+    };
+    struct {
+      int32_t *otni;
+    };
+    struct {
+      int32_t *toni;
+    };
+    struct {
+      int32_t *totni;
+    };
+    struct {
+      int32_t *(*fi)(int32_t *onti, int32_t *otni, int32_t *toni);
+    };
+  };
+} FullyTransparentMany_____i32;
+
+typedef union PartlyTransparentMany_Option_i32 {
+  const struct Option_Option_i32 *tao;
+  const struct Option_Option_i32 *toa;
+  const struct Option_Option_i32 *ota;
+  const struct Struct_Option_i32 *tas;
+  const struct Struct_Option_i32 *tsa;
+  const struct Struct_Option_i32 *sta;
+  const struct Option_Option_i32 *toat;
+  const struct Struct_Option_i32 *tsat;
+  const struct Option_i32 *taoi;
+  const struct Option_i32 *toai;
+  const struct Option_i32 *otai;
+  const struct Struct_i32 *tasi;
+  const struct Struct_i32 *tsai;
+  const struct Struct_i32 *stai;
+  const struct Option_i32 *toati;
+  const struct Struct_i32 *tsati;
+} PartlyTransparentMany_Option_i32;
+
+void root_opaque(const struct Opaque_i32 *o);
+
+void root1(struct FullyTransparent1_i32 a, struct NotTransparent1_Option_i32 s);
+
+void root2(struct FullyTransparent2_i32 a,
+           struct PartlyTransparent2_Option_i32 s,
+           struct NotTransparent2_Struct_Option_i32 n);
+
+void root_many(struct FullyTransparentMany_____i32 a, union PartlyTransparentMany_Option_i32 b);

--- a/tests/expectations/transparent_typedef_both.compat.c
+++ b/tests/expectations/transparent_typedef_both.compat.c
@@ -1,0 +1,237 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Opaque_i32 Opaque_i32;
+
+typedef struct Option_Option_Struct_Option_i32 Option_Option_Struct_Option_i32;
+
+typedef struct Option_Option_i32 Option_Option_i32;
+
+typedef struct Option_Struct_Option_i32 Option_Struct_Option_i32;
+
+typedef struct Option_Struct_Struct_Option_i32 Option_Struct_Struct_Option_i32;
+
+typedef struct Option_Struct_i32 Option_Struct_i32;
+
+typedef struct Option_i32 Option_i32;
+
+typedef struct FullyTransparent1_i32 {
+  int32_t a;
+  int32_t *n;
+  int32_t t;
+  int32_t (*f)(int32_t a, int32_t *n);
+  int32_t ai;
+  int32_t *ni;
+  int32_t ti;
+  int32_t (*fi)(int32_t ai, int32_t *ni);
+} FullyTransparent1_i32;
+
+typedef struct Struct_Option_i32 {
+  const struct Option_i32 *field;
+} Struct_Option_i32;
+
+typedef struct Option_i32 Typedef_Option_i32;
+
+typedef struct Struct_i32 {
+  const int32_t *field;
+} Struct_i32;
+
+typedef int32_t Typedef_i32;
+
+typedef struct NotTransparent1_Option_i32 {
+  const struct Option_Option_i32 *o;
+  const struct Struct_Option_i32 *s;
+  const Typedef_Option_i32 *t;
+  Typedef_Option_i32 *(*f)(const struct Option_Option_i32 *o, const struct Struct_Option_i32 *s);
+  const struct Option_i32 *oi;
+  const struct Struct_i32 *si;
+  const Typedef_i32 *ti;
+  Typedef_i32 *(*fi)(const struct Option_i32 *oi, const struct Struct_i32 *si);
+} NotTransparent1_Option_i32;
+
+typedef struct FullyTransparent2_i32 {
+  int32_t aa;
+  int32_t *an;
+  int32_t at;
+  int32_t *na;
+  int32_t **nn;
+  int32_t *nt;
+  int32_t *on;
+  int32_t ta;
+  int32_t *tn;
+  int32_t tt;
+  int32_t (*f)(int32_t aa,
+               int32_t *an,
+               int32_t at,
+               int32_t *na,
+               int32_t **nn,
+               int32_t *nt,
+               int32_t *on,
+               int32_t ta,
+               int32_t *tn);
+  int32_t aai;
+  int32_t *ani;
+  int32_t ati;
+  int32_t *nai;
+  int32_t **nni;
+  int32_t *nti;
+  int32_t *oni;
+  int32_t tai;
+  int32_t *tni;
+  int32_t tti;
+  int32_t (*fi)(int32_t aai,
+                int32_t *ani,
+                int32_t ati,
+                int32_t *nai,
+                int32_t **nni,
+                int32_t *nti,
+                int32_t *oni,
+                int32_t tai,
+                int32_t *tni);
+} FullyTransparent2_i32;
+
+typedef struct PartlyTransparent2_Option_i32 {
+  const struct Option_Option_i32 *ao;
+  const struct Struct_Option_i32 *aS;
+  const Typedef_Option_i32 *at;
+  struct Option_Option_i32 *const *no;
+  struct Struct_Option_i32 *const *ns;
+  Typedef_Option_i32 *const *nt;
+  Typedef_Option_i32 **(*f)(const struct Option_Option_i32 *ao,
+                            const struct Struct_Option_i32 *aS,
+                            const Typedef_Option_i32 *at,
+                            struct Option_Option_i32 *const *no,
+                            struct Struct_Option_i32 *const *ns);
+  const struct Option_i32 *aoi;
+  const struct Struct_i32 *asi;
+  const Typedef_i32 *ati;
+  struct Option_i32 *const *noi;
+  struct Struct_i32 *const *nsi;
+  Typedef_i32 *const *nti;
+  Typedef_i32 **(*fi)(const struct Option_i32 *aoi,
+                      const struct Struct_i32 *asi,
+                      const Typedef_i32 *ati,
+                      struct Option_i32 *const *noi,
+                      struct Struct_i32 *const *nsi);
+} PartlyTransparent2_Option_i32;
+
+typedef struct Struct_Option_Struct_Option_i32 {
+  const struct Option_Struct_Option_i32 *field;
+} Struct_Option_Struct_Option_i32;
+
+typedef struct Struct_Struct_Option_i32 {
+  const struct Struct_Option_i32 *field;
+} Struct_Struct_Option_i32;
+
+typedef struct Struct_Struct_Struct_Option_i32 {
+  const struct Struct_Struct_Option_i32 *field;
+} Struct_Struct_Struct_Option_i32;
+
+typedef struct Struct_Struct_i32 {
+  const struct Struct_i32 *field;
+} Struct_Struct_i32;
+
+typedef struct NotTransparent2_Struct_Option_i32 {
+  const struct Option_Option_Struct_Option_i32 *oo;
+  const struct Option_Struct_Struct_Option_i32 *os;
+  const struct Struct_Option_Struct_Option_i32 *so;
+  const struct Struct_Struct_Struct_Option_i32 *ss;
+  struct Struct_Struct_Struct_Option_i32 *(*f)(const struct Option_Option_Struct_Option_i32 *oo,
+                                               const struct Option_Struct_Struct_Option_i32 *os,
+                                               const struct Struct_Option_Struct_Option_i32 *so);
+  const struct Option_Option_i32 *ooi;
+  const struct Option_Struct_i32 *osi;
+  const struct Struct_Option_i32 *soi;
+  const struct Struct_Struct_i32 *ssi;
+  struct Struct_Struct_i32 *(*fi)(const struct Option_Option_i32 *ooi,
+                                  const struct Option_Struct_i32 *osi,
+                                  const struct Struct_Option_i32 *soi);
+} NotTransparent2_Struct_Option_i32;
+
+typedef enum FullyTransparentMany_____i32_Tag {
+  ont_____i32,
+  otn_____i32,
+  ton_____i32,
+  totn_____i32,
+  f_____i32,
+  onti_____i32,
+  otni_____i32,
+  toni_____i32,
+  totni_____i32,
+  fi_____i32,
+} FullyTransparentMany_____i32_Tag;
+
+typedef struct FullyTransparentMany_____i32 {
+  FullyTransparentMany_____i32_Tag tag;
+  union {
+    struct {
+      int32_t **ont;
+    };
+    struct {
+      int32_t **otn;
+    };
+    struct {
+      int32_t **ton;
+    };
+    struct {
+      int32_t **totn;
+    };
+    struct {
+      int32_t **(*f)(int32_t **ont, int32_t **otn, int32_t **ton);
+    };
+    struct {
+      int32_t *onti;
+    };
+    struct {
+      int32_t *otni;
+    };
+    struct {
+      int32_t *toni;
+    };
+    struct {
+      int32_t *totni;
+    };
+    struct {
+      int32_t *(*fi)(int32_t *onti, int32_t *otni, int32_t *toni);
+    };
+  };
+} FullyTransparentMany_____i32;
+
+typedef union PartlyTransparentMany_Option_i32 {
+  const struct Option_Option_i32 *tao;
+  const struct Option_Option_i32 *toa;
+  const struct Option_Option_i32 *ota;
+  const struct Struct_Option_i32 *tas;
+  const struct Struct_Option_i32 *tsa;
+  const struct Struct_Option_i32 *sta;
+  const struct Option_Option_i32 *toat;
+  const struct Struct_Option_i32 *tsat;
+  const struct Option_i32 *taoi;
+  const struct Option_i32 *toai;
+  const struct Option_i32 *otai;
+  const struct Struct_i32 *tasi;
+  const struct Struct_i32 *tsai;
+  const struct Struct_i32 *stai;
+  const struct Option_i32 *toati;
+  const struct Struct_i32 *tsati;
+} PartlyTransparentMany_Option_i32;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root_opaque(const struct Opaque_i32 *o);
+
+void root1(struct FullyTransparent1_i32 a, struct NotTransparent1_Option_i32 s);
+
+void root2(struct FullyTransparent2_i32 a,
+           struct PartlyTransparent2_Option_i32 s,
+           struct NotTransparent2_Struct_Option_i32 n);
+
+void root_many(struct FullyTransparentMany_____i32 a, union PartlyTransparentMany_Option_i32 b);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tests/expectations/transparent_typedef_tag.c
+++ b/tests/expectations/transparent_typedef_tag.c
@@ -1,0 +1,229 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque_i32;
+
+struct Option_Option_Struct_Option_i32;
+
+struct Option_Option_i32;
+
+struct Option_Struct_Option_i32;
+
+struct Option_Struct_Struct_Option_i32;
+
+struct Option_Struct_i32;
+
+struct Option_i32;
+
+struct FullyTransparent1_i32 {
+  int32_t a;
+  int32_t *n;
+  int32_t t;
+  int32_t (*f)(int32_t a, int32_t *n);
+  int32_t ai;
+  int32_t *ni;
+  int32_t ti;
+  int32_t (*fi)(int32_t ai, int32_t *ni);
+};
+
+struct Struct_Option_i32 {
+  const struct Option_i32 *field;
+};
+
+typedef struct Option_i32 Typedef_Option_i32;
+
+struct Struct_i32 {
+  const int32_t *field;
+};
+
+typedef int32_t Typedef_i32;
+
+struct NotTransparent1_Option_i32 {
+  const struct Option_Option_i32 *o;
+  const struct Struct_Option_i32 *s;
+  const Typedef_Option_i32 *t;
+  Typedef_Option_i32 *(*f)(const struct Option_Option_i32 *o, const struct Struct_Option_i32 *s);
+  const struct Option_i32 *oi;
+  const struct Struct_i32 *si;
+  const Typedef_i32 *ti;
+  Typedef_i32 *(*fi)(const struct Option_i32 *oi, const struct Struct_i32 *si);
+};
+
+struct FullyTransparent2_i32 {
+  int32_t aa;
+  int32_t *an;
+  int32_t at;
+  int32_t *na;
+  int32_t **nn;
+  int32_t *nt;
+  int32_t *on;
+  int32_t ta;
+  int32_t *tn;
+  int32_t tt;
+  int32_t (*f)(int32_t aa,
+               int32_t *an,
+               int32_t at,
+               int32_t *na,
+               int32_t **nn,
+               int32_t *nt,
+               int32_t *on,
+               int32_t ta,
+               int32_t *tn);
+  int32_t aai;
+  int32_t *ani;
+  int32_t ati;
+  int32_t *nai;
+  int32_t **nni;
+  int32_t *nti;
+  int32_t *oni;
+  int32_t tai;
+  int32_t *tni;
+  int32_t tti;
+  int32_t (*fi)(int32_t aai,
+                int32_t *ani,
+                int32_t ati,
+                int32_t *nai,
+                int32_t **nni,
+                int32_t *nti,
+                int32_t *oni,
+                int32_t tai,
+                int32_t *tni);
+};
+
+struct PartlyTransparent2_Option_i32 {
+  const struct Option_Option_i32 *ao;
+  const struct Struct_Option_i32 *aS;
+  const Typedef_Option_i32 *at;
+  struct Option_Option_i32 *const *no;
+  struct Struct_Option_i32 *const *ns;
+  Typedef_Option_i32 *const *nt;
+  Typedef_Option_i32 **(*f)(const struct Option_Option_i32 *ao,
+                            const struct Struct_Option_i32 *aS,
+                            const Typedef_Option_i32 *at,
+                            struct Option_Option_i32 *const *no,
+                            struct Struct_Option_i32 *const *ns);
+  const struct Option_i32 *aoi;
+  const struct Struct_i32 *asi;
+  const Typedef_i32 *ati;
+  struct Option_i32 *const *noi;
+  struct Struct_i32 *const *nsi;
+  Typedef_i32 *const *nti;
+  Typedef_i32 **(*fi)(const struct Option_i32 *aoi,
+                      const struct Struct_i32 *asi,
+                      const Typedef_i32 *ati,
+                      struct Option_i32 *const *noi,
+                      struct Struct_i32 *const *nsi);
+};
+
+struct Struct_Option_Struct_Option_i32 {
+  const struct Option_Struct_Option_i32 *field;
+};
+
+struct Struct_Struct_Option_i32 {
+  const struct Struct_Option_i32 *field;
+};
+
+struct Struct_Struct_Struct_Option_i32 {
+  const struct Struct_Struct_Option_i32 *field;
+};
+
+struct Struct_Struct_i32 {
+  const struct Struct_i32 *field;
+};
+
+struct NotTransparent2_Struct_Option_i32 {
+  const struct Option_Option_Struct_Option_i32 *oo;
+  const struct Option_Struct_Struct_Option_i32 *os;
+  const struct Struct_Option_Struct_Option_i32 *so;
+  const struct Struct_Struct_Struct_Option_i32 *ss;
+  struct Struct_Struct_Struct_Option_i32 *(*f)(const struct Option_Option_Struct_Option_i32 *oo,
+                                               const struct Option_Struct_Struct_Option_i32 *os,
+                                               const struct Struct_Option_Struct_Option_i32 *so);
+  const struct Option_Option_i32 *ooi;
+  const struct Option_Struct_i32 *osi;
+  const struct Struct_Option_i32 *soi;
+  const struct Struct_Struct_i32 *ssi;
+  struct Struct_Struct_i32 *(*fi)(const struct Option_Option_i32 *ooi,
+                                  const struct Option_Struct_i32 *osi,
+                                  const struct Struct_Option_i32 *soi);
+};
+
+enum FullyTransparentMany_____i32_Tag {
+  ont_____i32,
+  otn_____i32,
+  ton_____i32,
+  totn_____i32,
+  f_____i32,
+  onti_____i32,
+  otni_____i32,
+  toni_____i32,
+  totni_____i32,
+  fi_____i32,
+};
+
+struct FullyTransparentMany_____i32 {
+  enum FullyTransparentMany_____i32_Tag tag;
+  union {
+    struct {
+      int32_t **ont;
+    };
+    struct {
+      int32_t **otn;
+    };
+    struct {
+      int32_t **ton;
+    };
+    struct {
+      int32_t **totn;
+    };
+    struct {
+      int32_t **(*f)(int32_t **ont, int32_t **otn, int32_t **ton);
+    };
+    struct {
+      int32_t *onti;
+    };
+    struct {
+      int32_t *otni;
+    };
+    struct {
+      int32_t *toni;
+    };
+    struct {
+      int32_t *totni;
+    };
+    struct {
+      int32_t *(*fi)(int32_t *onti, int32_t *otni, int32_t *toni);
+    };
+  };
+};
+
+union PartlyTransparentMany_Option_i32 {
+  const struct Option_Option_i32 *tao;
+  const struct Option_Option_i32 *toa;
+  const struct Option_Option_i32 *ota;
+  const struct Struct_Option_i32 *tas;
+  const struct Struct_Option_i32 *tsa;
+  const struct Struct_Option_i32 *sta;
+  const struct Option_Option_i32 *toat;
+  const struct Struct_Option_i32 *tsat;
+  const struct Option_i32 *taoi;
+  const struct Option_i32 *toai;
+  const struct Option_i32 *otai;
+  const struct Struct_i32 *tasi;
+  const struct Struct_i32 *tsai;
+  const struct Struct_i32 *stai;
+  const struct Option_i32 *toati;
+  const struct Struct_i32 *tsati;
+};
+
+void root_opaque(const struct Opaque_i32 *o);
+
+void root1(struct FullyTransparent1_i32 a, struct NotTransparent1_Option_i32 s);
+
+void root2(struct FullyTransparent2_i32 a,
+           struct PartlyTransparent2_Option_i32 s,
+           struct NotTransparent2_Struct_Option_i32 n);
+
+void root_many(struct FullyTransparentMany_____i32 a, union PartlyTransparentMany_Option_i32 b);

--- a/tests/expectations/transparent_typedef_tag.compat.c
+++ b/tests/expectations/transparent_typedef_tag.compat.c
@@ -1,0 +1,237 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Opaque_i32;
+
+struct Option_Option_Struct_Option_i32;
+
+struct Option_Option_i32;
+
+struct Option_Struct_Option_i32;
+
+struct Option_Struct_Struct_Option_i32;
+
+struct Option_Struct_i32;
+
+struct Option_i32;
+
+struct FullyTransparent1_i32 {
+  int32_t a;
+  int32_t *n;
+  int32_t t;
+  int32_t (*f)(int32_t a, int32_t *n);
+  int32_t ai;
+  int32_t *ni;
+  int32_t ti;
+  int32_t (*fi)(int32_t ai, int32_t *ni);
+};
+
+struct Struct_Option_i32 {
+  const struct Option_i32 *field;
+};
+
+typedef struct Option_i32 Typedef_Option_i32;
+
+struct Struct_i32 {
+  const int32_t *field;
+};
+
+typedef int32_t Typedef_i32;
+
+struct NotTransparent1_Option_i32 {
+  const struct Option_Option_i32 *o;
+  const struct Struct_Option_i32 *s;
+  const Typedef_Option_i32 *t;
+  Typedef_Option_i32 *(*f)(const struct Option_Option_i32 *o, const struct Struct_Option_i32 *s);
+  const struct Option_i32 *oi;
+  const struct Struct_i32 *si;
+  const Typedef_i32 *ti;
+  Typedef_i32 *(*fi)(const struct Option_i32 *oi, const struct Struct_i32 *si);
+};
+
+struct FullyTransparent2_i32 {
+  int32_t aa;
+  int32_t *an;
+  int32_t at;
+  int32_t *na;
+  int32_t **nn;
+  int32_t *nt;
+  int32_t *on;
+  int32_t ta;
+  int32_t *tn;
+  int32_t tt;
+  int32_t (*f)(int32_t aa,
+               int32_t *an,
+               int32_t at,
+               int32_t *na,
+               int32_t **nn,
+               int32_t *nt,
+               int32_t *on,
+               int32_t ta,
+               int32_t *tn);
+  int32_t aai;
+  int32_t *ani;
+  int32_t ati;
+  int32_t *nai;
+  int32_t **nni;
+  int32_t *nti;
+  int32_t *oni;
+  int32_t tai;
+  int32_t *tni;
+  int32_t tti;
+  int32_t (*fi)(int32_t aai,
+                int32_t *ani,
+                int32_t ati,
+                int32_t *nai,
+                int32_t **nni,
+                int32_t *nti,
+                int32_t *oni,
+                int32_t tai,
+                int32_t *tni);
+};
+
+struct PartlyTransparent2_Option_i32 {
+  const struct Option_Option_i32 *ao;
+  const struct Struct_Option_i32 *aS;
+  const Typedef_Option_i32 *at;
+  struct Option_Option_i32 *const *no;
+  struct Struct_Option_i32 *const *ns;
+  Typedef_Option_i32 *const *nt;
+  Typedef_Option_i32 **(*f)(const struct Option_Option_i32 *ao,
+                            const struct Struct_Option_i32 *aS,
+                            const Typedef_Option_i32 *at,
+                            struct Option_Option_i32 *const *no,
+                            struct Struct_Option_i32 *const *ns);
+  const struct Option_i32 *aoi;
+  const struct Struct_i32 *asi;
+  const Typedef_i32 *ati;
+  struct Option_i32 *const *noi;
+  struct Struct_i32 *const *nsi;
+  Typedef_i32 *const *nti;
+  Typedef_i32 **(*fi)(const struct Option_i32 *aoi,
+                      const struct Struct_i32 *asi,
+                      const Typedef_i32 *ati,
+                      struct Option_i32 *const *noi,
+                      struct Struct_i32 *const *nsi);
+};
+
+struct Struct_Option_Struct_Option_i32 {
+  const struct Option_Struct_Option_i32 *field;
+};
+
+struct Struct_Struct_Option_i32 {
+  const struct Struct_Option_i32 *field;
+};
+
+struct Struct_Struct_Struct_Option_i32 {
+  const struct Struct_Struct_Option_i32 *field;
+};
+
+struct Struct_Struct_i32 {
+  const struct Struct_i32 *field;
+};
+
+struct NotTransparent2_Struct_Option_i32 {
+  const struct Option_Option_Struct_Option_i32 *oo;
+  const struct Option_Struct_Struct_Option_i32 *os;
+  const struct Struct_Option_Struct_Option_i32 *so;
+  const struct Struct_Struct_Struct_Option_i32 *ss;
+  struct Struct_Struct_Struct_Option_i32 *(*f)(const struct Option_Option_Struct_Option_i32 *oo,
+                                               const struct Option_Struct_Struct_Option_i32 *os,
+                                               const struct Struct_Option_Struct_Option_i32 *so);
+  const struct Option_Option_i32 *ooi;
+  const struct Option_Struct_i32 *osi;
+  const struct Struct_Option_i32 *soi;
+  const struct Struct_Struct_i32 *ssi;
+  struct Struct_Struct_i32 *(*fi)(const struct Option_Option_i32 *ooi,
+                                  const struct Option_Struct_i32 *osi,
+                                  const struct Struct_Option_i32 *soi);
+};
+
+enum FullyTransparentMany_____i32_Tag {
+  ont_____i32,
+  otn_____i32,
+  ton_____i32,
+  totn_____i32,
+  f_____i32,
+  onti_____i32,
+  otni_____i32,
+  toni_____i32,
+  totni_____i32,
+  fi_____i32,
+};
+
+struct FullyTransparentMany_____i32 {
+  enum FullyTransparentMany_____i32_Tag tag;
+  union {
+    struct {
+      int32_t **ont;
+    };
+    struct {
+      int32_t **otn;
+    };
+    struct {
+      int32_t **ton;
+    };
+    struct {
+      int32_t **totn;
+    };
+    struct {
+      int32_t **(*f)(int32_t **ont, int32_t **otn, int32_t **ton);
+    };
+    struct {
+      int32_t *onti;
+    };
+    struct {
+      int32_t *otni;
+    };
+    struct {
+      int32_t *toni;
+    };
+    struct {
+      int32_t *totni;
+    };
+    struct {
+      int32_t *(*fi)(int32_t *onti, int32_t *otni, int32_t *toni);
+    };
+  };
+};
+
+union PartlyTransparentMany_Option_i32 {
+  const struct Option_Option_i32 *tao;
+  const struct Option_Option_i32 *toa;
+  const struct Option_Option_i32 *ota;
+  const struct Struct_Option_i32 *tas;
+  const struct Struct_Option_i32 *tsa;
+  const struct Struct_Option_i32 *sta;
+  const struct Option_Option_i32 *toat;
+  const struct Struct_Option_i32 *tsat;
+  const struct Option_i32 *taoi;
+  const struct Option_i32 *toai;
+  const struct Option_i32 *otai;
+  const struct Struct_i32 *tasi;
+  const struct Struct_i32 *tsai;
+  const struct Struct_i32 *stai;
+  const struct Option_i32 *toati;
+  const struct Struct_i32 *tsati;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void root_opaque(const struct Opaque_i32 *o);
+
+void root1(struct FullyTransparent1_i32 a, struct NotTransparent1_Option_i32 s);
+
+void root2(struct FullyTransparent2_i32 a,
+           struct PartlyTransparent2_Option_i32 s,
+           struct NotTransparent2_Struct_Option_i32 n);
+
+void root_many(struct FullyTransparentMany_____i32 a, union PartlyTransparentMany_Option_i32 b);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tests/expectations/transparent_typedef_tag.pyx
+++ b/tests/expectations/transparent_typedef_tag.pyx
@@ -1,0 +1,203 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef struct Opaque_i32:
+    pass
+
+  cdef struct Option_Option_Struct_Option_i32:
+    pass
+
+  cdef struct Option_Option_i32:
+    pass
+
+  cdef struct Option_Struct_Option_i32:
+    pass
+
+  cdef struct Option_Struct_Struct_Option_i32:
+    pass
+
+  cdef struct Option_Struct_i32:
+    pass
+
+  cdef struct Option_i32:
+    pass
+
+  cdef struct FullyTransparent1_i32:
+    int32_t a;
+    int32_t *n;
+    int32_t t;
+    int32_t (*f)(int32_t a, int32_t *n);
+    int32_t ai;
+    int32_t *ni;
+    int32_t ti;
+    int32_t (*fi)(int32_t ai, int32_t *ni);
+
+  cdef struct Struct_Option_i32:
+    const Option_i32 *field;
+
+  ctypedef Option_i32 Typedef_Option_i32;
+
+  cdef struct Struct_i32:
+    const int32_t *field;
+
+  ctypedef int32_t Typedef_i32;
+
+  cdef struct NotTransparent1_Option_i32:
+    const Option_Option_i32 *o;
+    const Struct_Option_i32 *s;
+    const Typedef_Option_i32 *t;
+    Typedef_Option_i32 *(*f)(const Option_Option_i32 *o, const Struct_Option_i32 *s);
+    const Option_i32 *oi;
+    const Struct_i32 *si;
+    const Typedef_i32 *ti;
+    Typedef_i32 *(*fi)(const Option_i32 *oi, const Struct_i32 *si);
+
+  cdef struct FullyTransparent2_i32:
+    int32_t aa;
+    int32_t *an;
+    int32_t at;
+    int32_t *na;
+    int32_t **nn;
+    int32_t *nt;
+    int32_t *on;
+    int32_t ta;
+    int32_t *tn;
+    int32_t tt;
+    int32_t (*f)(int32_t aa,
+                 int32_t *an,
+                 int32_t at,
+                 int32_t *na,
+                 int32_t **nn,
+                 int32_t *nt,
+                 int32_t *on,
+                 int32_t ta,
+                 int32_t *tn);
+    int32_t aai;
+    int32_t *ani;
+    int32_t ati;
+    int32_t *nai;
+    int32_t **nni;
+    int32_t *nti;
+    int32_t *oni;
+    int32_t tai;
+    int32_t *tni;
+    int32_t tti;
+    int32_t (*fi)(int32_t aai,
+                  int32_t *ani,
+                  int32_t ati,
+                  int32_t *nai,
+                  int32_t **nni,
+                  int32_t *nti,
+                  int32_t *oni,
+                  int32_t tai,
+                  int32_t *tni);
+
+  cdef struct PartlyTransparent2_Option_i32:
+    const Option_Option_i32 *ao;
+    const Struct_Option_i32 *aS;
+    const Typedef_Option_i32 *at;
+    Option_Option_i32 *const *no;
+    Struct_Option_i32 *const *ns;
+    Typedef_Option_i32 *const *nt;
+    Typedef_Option_i32 **(*f)(const Option_Option_i32 *ao,
+                              const Struct_Option_i32 *aS,
+                              const Typedef_Option_i32 *at,
+                              Option_Option_i32 *const *no,
+                              Struct_Option_i32 *const *ns);
+    const Option_i32 *aoi;
+    const Struct_i32 *asi;
+    const Typedef_i32 *ati;
+    Option_i32 *const *noi;
+    Struct_i32 *const *nsi;
+    Typedef_i32 *const *nti;
+    Typedef_i32 **(*fi)(const Option_i32 *aoi,
+                        const Struct_i32 *asi,
+                        const Typedef_i32 *ati,
+                        Option_i32 *const *noi,
+                        Struct_i32 *const *nsi);
+
+  cdef struct Struct_Option_Struct_Option_i32:
+    const Option_Struct_Option_i32 *field;
+
+  cdef struct Struct_Struct_Option_i32:
+    const Struct_Option_i32 *field;
+
+  cdef struct Struct_Struct_Struct_Option_i32:
+    const Struct_Struct_Option_i32 *field;
+
+  cdef struct Struct_Struct_i32:
+    const Struct_i32 *field;
+
+  cdef struct NotTransparent2_Struct_Option_i32:
+    const Option_Option_Struct_Option_i32 *oo;
+    const Option_Struct_Struct_Option_i32 *os;
+    const Struct_Option_Struct_Option_i32 *so;
+    const Struct_Struct_Struct_Option_i32 *ss;
+    Struct_Struct_Struct_Option_i32 *(*f)(const Option_Option_Struct_Option_i32 *oo,
+                                          const Option_Struct_Struct_Option_i32 *os,
+                                          const Struct_Option_Struct_Option_i32 *so);
+    const Option_Option_i32 *ooi;
+    const Option_Struct_i32 *osi;
+    const Struct_Option_i32 *soi;
+    const Struct_Struct_i32 *ssi;
+    Struct_Struct_i32 *(*fi)(const Option_Option_i32 *ooi,
+                             const Option_Struct_i32 *osi,
+                             const Struct_Option_i32 *soi);
+
+  cdef enum FullyTransparentMany_____i32_Tag:
+    ont_____i32,
+    otn_____i32,
+    ton_____i32,
+    totn_____i32,
+    f_____i32,
+    onti_____i32,
+    otni_____i32,
+    toni_____i32,
+    totni_____i32,
+    fi_____i32,
+
+  cdef struct FullyTransparentMany_____i32:
+    FullyTransparentMany_____i32_Tag tag;
+    int32_t **ont;
+    int32_t **otn;
+    int32_t **ton;
+    int32_t **totn;
+    int32_t **(*f)(int32_t **ont, int32_t **otn, int32_t **ton);
+    int32_t *onti;
+    int32_t *otni;
+    int32_t *toni;
+    int32_t *totni;
+    int32_t *(*fi)(int32_t *onti, int32_t *otni, int32_t *toni);
+
+  cdef union PartlyTransparentMany_Option_i32:
+    const Option_Option_i32 *tao;
+    const Option_Option_i32 *toa;
+    const Option_Option_i32 *ota;
+    const Struct_Option_i32 *tas;
+    const Struct_Option_i32 *tsa;
+    const Struct_Option_i32 *sta;
+    const Option_Option_i32 *toat;
+    const Struct_Option_i32 *tsat;
+    const Option_i32 *taoi;
+    const Option_i32 *toai;
+    const Option_i32 *otai;
+    const Struct_i32 *tasi;
+    const Struct_i32 *tsai;
+    const Struct_i32 *stai;
+    const Option_i32 *toati;
+    const Struct_i32 *tsati;
+
+  void root_opaque(const Opaque_i32 *o);
+
+  void root1(FullyTransparent1_i32 a, NotTransparent1_Option_i32 s);
+
+  void root2(FullyTransparent2_i32 a,
+             PartlyTransparent2_Option_i32 s,
+             NotTransparent2_Struct_Option_i32 n);
+
+  void root_many(FullyTransparentMany_____i32 a, PartlyTransparentMany_Option_i32 b);

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -19,4 +19,4 @@ pub struct Foo<T> {
 pub type NonNullPtr<X> = Option<NonNull<X>>;
 
 #[no_mangle]
-pub extern "C" fn root(arg: NonNull<i32>, foo: *mut Foo<u64>, d: NonNull<NonNull<Opaque>>, e: NonNullPtr<NonNull<bool>>) { }
+pub extern "C" fn root(arg: NonNull<i32>, foo: *mut Foo<u64>, d: NonNull<NonNull<Opaque>>) { }

--- a/tests/rust/nonnull.rs
+++ b/tests/rust/nonnull.rs
@@ -15,5 +15,8 @@ pub struct Foo<T> {
     i: Option<NonNull<NonNull<i32>>>,
 }
 
+/// cbindgen:transparent-typedef
+pub type NonNullPtr<X> = Option<NonNull<X>>;
+
 #[no_mangle]
-pub extern "C" fn root(arg: NonNull<i32>, foo: *mut Foo<u64>, d: NonNull<NonNull<Opaque>>) { }
+pub extern "C" fn root(arg: NonNull<i32>, foo: *mut Foo<u64>, d: NonNull<NonNull<Opaque>>, e: NonNullPtr<NonNull<bool>>) { }

--- a/tests/rust/transparent.rs
+++ b/tests/rust/transparent.rs
@@ -16,6 +16,10 @@ struct TransparentComplexWrappingStructure { only_field: DummyStruct }
 #[repr(transparent)]
 struct TransparentPrimitiveWrappingStructure { only_field: u32 }
 
+// Transparent struct wrapping a pointer
+#[repr(transparent)]
+struct TransparentPointerWrappingStructure { only_field: *const u32 }
+
 // Transparent struct wrapper with a marker wrapping a struct.
 #[repr(transparent)]
 struct TransparentComplexWrapper<T> {
@@ -53,10 +57,18 @@ impl TransparentPrimitiveWithAssociatedConstants {
     };
 }
 
+struct StructWithAssociatedConstantInImpl { }
+
+impl StructWithAssociatedConstantInImpl {
+    pub const STRUCT_TEN: TransparentPrimitiveWrappingStructure =
+        TransparentPrimitiveWrappingStructure { only_field: 10 };
+}
+
 enum EnumWithAssociatedConstantInImpl { A }
 
 impl EnumWithAssociatedConstantInImpl {
-    pub const TEN: TransparentPrimitiveWrappingStructure = TransparentPrimitiveWrappingStructure { only_field: 10 };
+    pub const ENUM_TEN: TransparentPrimitiveWrappingStructure =
+        TransparentPrimitiveWrappingStructure { only_field: 10 };
 }
 
 #[no_mangle]
@@ -69,5 +81,59 @@ pub extern "C" fn root(
     f: TransparentPrimitiveWrapper<i32>,
     g: TransparentPrimitiveWithAssociatedConstants,
     h: TransparentEmptyStructure,
-    i: EnumWithAssociatedConstantInImpl,
+    i: TransparentPointerWrappingStructure,
+    j: StructWithAssociatedConstantInImpl,
+    k: EnumWithAssociatedConstantInImpl,
+) { }
+
+#[repr(transparent)]
+/// cbindgen:transparent-typedef
+struct ErasedTransparentNonNullPointerWrappingStruct { only_field: NonNull<u32> }
+
+#[repr(transparent)]
+/// cbindgen:transparent-typedef
+struct ErasedTransparentOptionalNonNullPointerWrappingStruct { only_field: Option<NonNull<u32>> }
+
+#[repr(transparent)]
+/// cbindgen:transparent-typedef
+struct ErasedTransparentWrappingAnotherTransparentStruct { only_field: TransparentPrimitiveWrappingStructure }
+
+/// cbindgen:transparent-typedef
+#[repr(transparent)]
+struct ErasedTransparentWrappingTransparentNonNullPointerStruct { only_field: ErasedTransparentNonNullPointerWrappingStruct }
+
+// Transparent structure wrapping another type
+#[repr(transparent)]
+/// cbindgen:transparent-typedef
+struct ErasedTransparentStructWrappingAnotherType<T> { only_field: T }
+
+type TransparentIntStruct = ErasedTransparentStructWrappingAnotherType<i32>;
+type TransparentComplexStruct = ErasedTransparentStructWrappingAnotherType<DummyStruct>;
+type TransparentTransparentStruct = ErasedTransparentStructWrappingAnotherType<TransparentPrimitiveWrappingStructure>;
+type TransparentNonNullStruct = ErasedTransparentStructWrappingAnotherType<NonNull<u32>>;
+type TransparentOptionNonNullStruct = ErasedTransparentStructWrappingAnotherType<Option<NonNull<u32>>>;
+
+/// cbindgen:transparent-typedef
+type ErasedTransparentIntStruct = ErasedTransparentStructWrappingAnotherType<i32>;
+/// cbindgen:transparent-typedef
+type ErasedTransparentComplexStruct = ErasedTransparentStructWrappingAnotherType<DummyStruct>;
+/// cbindgen:transparent-typedef
+type ErasedTransparentOptionNonNullStruct = ErasedTransparentStructWrappingAnotherType<Option<NonNull<u32>>>;
+
+#[no_mangle]
+pub extern "C" fn erased_root(
+    a: ErasedTransparentNonNullPointerWrappingStruct,
+    b: ErasedTransparentOptionalNonNullPointerWrappingStruct,
+    c: ErasedTransparentWrappingAnotherTransparentStruct,
+    d: ErasedTransparentWrappingTransparentNonNullPointerStruct,
+    e: ErasedTransparentStructWrappingAnotherType<TransparentIntStruct>,
+    f: ErasedTransparentStructWrappingAnotherType<ErasedTransparentIntStruct>,
+    g: ErasedTransparentStructWrappingAnotherType<ErasedTransparentComplexStruct>,
+    h: ErasedTransparentStructWrappingAnotherType<ErasedTransparentOptionNonNullStruct>,
+    i: ErasedTransparentIntStruct,
+    j: TransparentIntStruct,
+    k: TransparentComplexStruct,
+    l: TransparentTransparentStruct,
+    m: TransparentNonNullStruct,
+    n: TransparentOptionNonNullStruct,
 ) { }

--- a/tests/rust/transparent_typedef.rs
+++ b/tests/rust/transparent_typedef.rs
@@ -23,10 +23,12 @@ pub struct FullyTransparent1<E = Alias<i64>> {
     a: Alias<E>,
     n: NonNull<E>,
     t: Transparent<E>,
+    f: extern "C" fn(a: Alias<E>, n: NonNull<E>) -> Transparent<E>,
 
     ai: Alias<i32>,
     ni: NonNull<i32>,
     ti: Transparent<i32>,
+    fi: extern "C" fn(ai: Alias<i32>, ni: NonNull<i32>) -> Transparent<i32>,
 }
 
 // Option<T> only gets erased if T is NonNull or NonZero; use references so it still compiles.
@@ -35,10 +37,12 @@ pub struct NotTransparent1<'a, E = Option<i64>> {
     o: &'a Option<E>,
     s: &'a Struct<E>,
     t: &'a Typedef<E>,
+    f: extern "C" fn(o: &Option<E>, s: &Struct<E>) -> *mut Typedef<E>,
 
     oi: &'a Option<i32>,
     si: &'a Struct<i32>,
     ti: &'a Typedef<i32>,
+    fi: extern "C" fn(oi: &Option<i32>, si: &Struct<i32>) -> *mut Typedef<i32>,
 }
 
 #[no_mangle]
@@ -67,6 +71,17 @@ pub struct FullyTransparent2<E = Option<NonZero<i32>>> {
     ta: Transparent<Alias<E>>,
     tn: Transparent<NonNull<E>>,
     tt: Transparent<Transparent<E>>,
+    f: extern "C" fn(
+        aa: Alias<Alias<E>>,
+        an: Alias<NonNull<E>>,
+        at: Alias<Transparent<E>>,
+        na: NonNull<Alias<E>>,
+        nn: NonNull<NonNull<E>>,
+        nt: NonNull<Transparent<E>>,
+        on: Option<NonNull<E>>,
+        ta: Transparent<Alias<E>>,
+        tn: Transparent<NonNull<E>>,
+    ) -> Transparent<Transparent<E>>,
 
     aai: Alias<Alias<i32>>,
     ani: Alias<NonNull<i32>>,
@@ -78,17 +93,35 @@ pub struct FullyTransparent2<E = Option<NonZero<i32>>> {
     tai: Transparent<Alias<i32>>,
     tni: Transparent<NonNull<i32>>,
     tti: Transparent<Transparent<i32>>,
+    fi: extern "C" fn(
+        aai: Alias<Alias<i32>>,
+        ani: Alias<NonNull<i32>>,
+        ati: Alias<Transparent<i32>>,
+        nai: NonNull<Alias<i32>>,
+        nni: NonNull<NonNull<i32>>,
+        nti: NonNull<Transparent<i32>>,
+        oni: Option<NonNull<i32>>,
+        tai: Transparent<Alias<i32>>,
+        tni: Transparent<NonNull<i32>>,
+    ) -> Transparent<Transparent<i32>>,
 }
 
 // Option<E> only gets erased if T is NonNull or NonZero; use references so it still compiles.
 #[repr(C)]
-pub struct PartlyTransparent2<'a, E> {
+pub struct PartlyTransparent2<'a, E = Option<Alias<i64>>> {
     ao: &'a Alias<Option<E>>,
     aS: &'a Alias<Struct<E>>,
     at: &'a Alias<Typedef<E>>,
     no: &'a NonNull<Option<E>>,
     ns: &'a NonNull<Struct<E>>,
     nt: &'a NonNull<Typedef<E>>,
+    f: extern "C" fn(
+        ao: &Alias<Option<E>>,
+        aS: &Alias<Struct<E>>,
+        at: &Alias<Typedef<E>>,
+        no: &NonNull<Option<E>>,
+        ns: &NonNull<Struct<E>>,
+    ) -> *mut NonNull<Typedef<E>>,
 
     aoi: &'a Alias<Option<i32>>,
     asi: &'a Alias<Struct<i32>>,
@@ -96,20 +129,37 @@ pub struct PartlyTransparent2<'a, E> {
     noi: &'a NonNull<Option<i32>>,
     nsi: &'a NonNull<Struct<i32>>,
     nti: &'a NonNull<Typedef<i32>>,
+    fi: extern "C" fn(
+        aoi: &Alias<Option<i32>>,
+        asi: &Alias<Struct<i32>>,
+        ati: &Alias<Typedef<i32>>,
+        noi: &NonNull<Option<i32>>,
+        nsi: &NonNull<Struct<i32>>,
+    ) -> *mut NonNull<Typedef<i32>>,
 }
 
 // Use references so it still compiles.
 #[repr(C)]
-pub struct NotTransparent2<'a, E = Option<Struct<i32>>> {
+pub struct NotTransparent2<'a, E = Option<Struct<i64>>> {
     oo: &'a Option<Option<E>>,
     os: &'a Option<Struct<E>>,
     so: &'a Struct<Option<E>>,
     ss: &'a Struct<Struct<E>>,
+    f: extern "C" fn(
+        oo: &Option<Option<E>>,
+        os: &Option<Struct<E>>,
+        so: &Struct<Option<E>>,
+    ) -> *mut Struct<Struct<E>>,
 
     ooi: &'a Option<Option<i32>>,
     osi: &'a Option<Struct<i32>>,
     soi: &'a Struct<Option<i32>>,
     ssi: &'a Struct<Struct<i32>>,
+    fi: extern "C" fn(
+        ooi: &Option<Option<i32>>,
+        osi: &Option<Struct<i32>>,
+        soi: &Struct<Option<i32>>,
+    ) -> *mut Struct<Struct<i32>>,
 }
 
 #[no_mangle]
@@ -119,7 +169,7 @@ pub extern "C" fn root2(
     n: NotTransparent2<Struct<Option<i32>>>) {}
 
 #[repr(C)]
-pub struct FullyTransparentMany<E = Alias<Option<Transparent<NonNull<Transparent<i64>>>>>> {
+pub struct FullyTransparentMany<E = Alias<Option<Transparent<NonZero<Transparent<i64>>>>>> {
     ont: Option<NonNull<Transparent<E>>>,
     otn: Option<Transparent<NonNull<E>>>,
     ton: Transparent<Option<NonNull<E>>>,
@@ -127,16 +177,29 @@ pub struct FullyTransparentMany<E = Alias<Option<Transparent<NonNull<Transparent
     // One erasable quadruple
     totn: Transparent<Option<Transparent<NonNull<E>>>>,
 
+    f: extern "C" fn(
+        ont: Option<NonNull<Transparent<E>>>,
+        otn: Option<Transparent<NonNull<E>>>,
+        ton: Transparent<Option<NonNull<E>>>,
+    ) -> Transparent<Option<Transparent<NonNull<E>>>>,
+
     onti: Option<NonNull<Transparent<i32>>>,
     otni: Option<Transparent<NonNull<i32>>>,
     toni: Transparent<Option<NonNull<i32>>>,
 
     // One erasable quadruple
     totni: Transparent<Option<Transparent<NonNull<i32>>>>,
+
+    fi: extern "C" fn(
+        onti: Option<NonNull<Transparent<i32>>>,
+        otni: Option<Transparent<NonNull<i32>>>,
+        toni: Transparent<Option<NonNull<i32>>>,
+    ) -> Transparent<Option<Transparent<NonNull<i32>>>>,
+
 }
 
 #[repr(C)]
-pub struct PartlyTransparentMany<'a, E> {
+pub struct PartlyTransparentMany<'a, E = Transparent<Option<Alias<i64>>>> {
     // A few triples
     tao: &'a Transparent<Alias<Option<E>>>,
     toa: &'a Transparent<Option<Alias<E>>>,

--- a/tests/rust/transparent_typedef.rs
+++ b/tests/rust/transparent_typedef.rs
@@ -1,9 +1,14 @@
 use std::num::NonZero;
 use std::ptr::NonNull;
 
+pub struct Opaque<U = Alias<i32>>;
+
+#[no_mangle]
+pub extern "C" fn root_opaque(o: Opaque<Alias<Option<NonZero<i32>>>>) {}
+
 #[repr(C)]
-pub struct Struct<T> {
-    field: T,
+pub struct Struct<U = Alias<U>> {
+    field: U,
 }
 
 /// cbindgen:transparent-typedef
@@ -169,37 +174,37 @@ pub extern "C" fn root2(
     n: NotTransparent2<Struct<Option<i32>>>) {}
 
 #[repr(C)]
-pub struct FullyTransparentMany<E = Alias<Option<Transparent<NonZero<Transparent<i64>>>>>> {
-    ont: Option<NonNull<Transparent<E>>>,
-    otn: Option<Transparent<NonNull<E>>>,
-    ton: Transparent<Option<NonNull<E>>>,
+pub enum FullyTransparentMany<E = Alias<Option<Transparent<NonZero<Transparent<i64>>>>>> {
+    ont(Option<NonNull<Transparent<E>>>),
+    otn(Option<Transparent<NonNull<E>>>),
+    ton(Transparent<Option<NonNull<E>>>),
 
     // One erasable quadruple
-    totn: Transparent<Option<Transparent<NonNull<E>>>>,
+    totn(Transparent<Option<Transparent<NonNull<E>>>>),
 
-    f: extern "C" fn(
+    f(extern "C" fn(
         ont: Option<NonNull<Transparent<E>>>,
         otn: Option<Transparent<NonNull<E>>>,
         ton: Transparent<Option<NonNull<E>>>,
-    ) -> Transparent<Option<Transparent<NonNull<E>>>>,
+    ) -> Transparent<Option<Transparent<NonNull<E>>>>),
 
-    onti: Option<NonNull<Transparent<i32>>>,
-    otni: Option<Transparent<NonNull<i32>>>,
-    toni: Transparent<Option<NonNull<i32>>>,
+    onti(Option<NonNull<Transparent<i32>>>),
+    otni(Option<Transparent<NonNull<i32>>>),
+    toni(Transparent<Option<NonNull<i32>>>),
 
     // One erasable quadruple
-    totni: Transparent<Option<Transparent<NonNull<i32>>>>,
+    totni(Transparent<Option<Transparent<NonNull<i32>>>>),
 
-    fi: extern "C" fn(
+    fi(extern "C" fn(
         onti: Option<NonNull<Transparent<i32>>>,
         otni: Option<Transparent<NonNull<i32>>>,
         toni: Transparent<Option<NonNull<i32>>>,
-    ) -> Transparent<Option<Transparent<NonNull<i32>>>>,
+    ) -> Transparent<Option<Transparent<NonNull<i32>>>>),
 
 }
 
 #[repr(C)]
-pub struct PartlyTransparentMany<'a, E = Transparent<Option<Alias<i64>>>> {
+pub union PartlyTransparentMany<'a, E = Transparent<Option<Alias<i64>>>> {
     // A few triples
     tao: &'a Transparent<Alias<Option<E>>>,
     toa: &'a Transparent<Option<Alias<E>>>,

--- a/tests/rust/transparent_typedef.rs
+++ b/tests/rust/transparent_typedef.rs
@@ -1,19 +1,10 @@
 use std::num::NonZero;
 use std::ptr::NonNull;
 
-pub struct Opaque<U = Alias<i32>>;
-
-#[no_mangle]
-pub extern "C" fn root_opaque(o: Opaque<Alias<Option<NonZero<i32>>>>) {}
-
-#[repr(C)]
-pub struct Struct<U = Alias<U>> {
-    field: U,
-}
 
 /// cbindgen:transparent-typedef
 #[repr(transparent)]
-pub struct Transparent<T, P=T> {
+pub struct Transparent<T, P=NonNull<T>> {
     field: T,
     _phantom: std::marker::PhantomData<P>,
 }
@@ -22,6 +13,19 @@ pub type Typedef<U = Transparent<i64>> = Transparent<U>;
 
 /// cbindgen:transparent-typedef
 pub type Alias<U = Transparent<i64>> = Transparent<U>;
+
+pub struct Opaque<U = Alias<i32>> {
+    field: U,
+}
+
+#[no_mangle]
+pub extern "C" fn root_opaque(o: &Opaque<Alias<Option<NonZero<i32>>>>) {}
+
+#[repr(C)]
+pub struct Struct<'a, U, P = Alias<U>> {
+    field: &'a U,
+    _phantom: std::marker::PhantomData<P>,
+}
 
 #[repr(C)]
 pub struct FullyTransparent1<E = Alias<i64>> {
@@ -49,15 +53,6 @@ pub struct NotTransparent1<'a, E = Option<i64>> {
     ti: &'a Typedef<i32>,
     fi: extern "C" fn(oi: &Option<i32>, si: &Struct<i32>) -> *mut Typedef<i32>,
 }
-
-#[no_mangle]
-pub extern "C" fn test1(
-    a: Struct<i32>,
-    b: Typedef<i32>,
-    c: &Option<i32>,
-    d: Transparent<i32>,
-    e: Alias<i32>,
-) {}
 
 #[no_mangle]
 pub extern "C" fn root1(
@@ -174,7 +169,7 @@ pub extern "C" fn root2(
     n: NotTransparent2<Struct<Option<i32>>>) {}
 
 #[repr(C)]
-pub enum FullyTransparentMany<E = Alias<Option<Transparent<NonZero<Transparent<i64>>>>>> {
+pub enum FullyTransparentMany<E = Alias<Option<Transparent<NonNull<Transparent<i64>>>>>> {
     ont(Option<NonNull<Transparent<E>>>),
     otn(Option<Transparent<NonNull<E>>>),
     ton(Transparent<Option<NonNull<E>>>),

--- a/tests/rust/transparent_typedef.rs
+++ b/tests/rust/transparent_typedef.rs
@@ -1,0 +1,169 @@
+use std::num::NonZero;
+use std::ptr::NonNull;
+
+#[repr(C)]
+pub struct Struct<T> {
+    field: T,
+}
+
+/// cbindgen:transparent-typedef
+#[repr(transparent)]
+pub struct Transparent<T, P=T> {
+    field: T,
+    _phantom: std::marker::PhantomData<P>,
+}
+
+pub type Typedef<U = Transparent<i64>> = Transparent<U>;
+
+/// cbindgen:transparent-typedef
+pub type Alias<U = Transparent<i64>> = Transparent<U>;
+
+#[repr(C)]
+pub struct FullyTransparent1<E = Alias<i64>> {
+    a: Alias<E>,
+    n: NonNull<E>,
+    t: Transparent<E>,
+
+    ai: Alias<i32>,
+    ni: NonNull<i32>,
+    ti: Transparent<i32>,
+}
+
+// Option<T> only gets erased if T is NonNull or NonZero; use references so it still compiles.
+#[repr(C)]
+pub struct NotTransparent1<'a, E = Option<i64>> {
+    o: &'a Option<E>,
+    s: &'a Struct<E>,
+    t: &'a Typedef<E>,
+
+    oi: &'a Option<i32>,
+    si: &'a Struct<i32>,
+    ti: &'a Typedef<i32>,
+}
+
+#[no_mangle]
+pub extern "C" fn test1(
+    a: Struct<i32>,
+    b: Typedef<i32>,
+    c: &Option<i32>,
+    d: Transparent<i32>,
+    e: Alias<i32>,
+) {}
+
+#[no_mangle]
+pub extern "C" fn root1(
+    a: FullyTransparent1<Alias<i32>>,
+    s: NotTransparent1<Option<i32>>) {}
+
+#[repr(C)]
+pub struct FullyTransparent2<E = Option<NonZero<i32>>> {
+    aa: Alias<Alias<E>>,
+    an: Alias<NonNull<E>>,
+    at: Alias<Transparent<E>>,
+    na: NonNull<Alias<E>>,
+    nn: NonNull<NonNull<E>>,
+    nt: NonNull<Transparent<E>>,
+    on: Option<NonNull<E>>,
+    ta: Transparent<Alias<E>>,
+    tn: Transparent<NonNull<E>>,
+    tt: Transparent<Transparent<E>>,
+
+    aai: Alias<Alias<i32>>,
+    ani: Alias<NonNull<i32>>,
+    ati: Alias<Transparent<i32>>,
+    nai: NonNull<Alias<i32>>,
+    nni: NonNull<NonNull<i32>>,
+    nti: NonNull<Transparent<i32>>,
+    oni: Option<NonNull<i32>>,
+    tai: Transparent<Alias<i32>>,
+    tni: Transparent<NonNull<i32>>,
+    tti: Transparent<Transparent<i32>>,
+}
+
+// Option<E> only gets erased if T is NonNull or NonZero; use references so it still compiles.
+#[repr(C)]
+pub struct PartlyTransparent2<'a, E> {
+    ao: &'a Alias<Option<E>>,
+    aS: &'a Alias<Struct<E>>,
+    at: &'a Alias<Typedef<E>>,
+    no: &'a NonNull<Option<E>>,
+    ns: &'a NonNull<Struct<E>>,
+    nt: &'a NonNull<Typedef<E>>,
+
+    aoi: &'a Alias<Option<i32>>,
+    asi: &'a Alias<Struct<i32>>,
+    ati: &'a Alias<Typedef<i32>>,
+    noi: &'a NonNull<Option<i32>>,
+    nsi: &'a NonNull<Struct<i32>>,
+    nti: &'a NonNull<Typedef<i32>>,
+}
+
+// Use references so it still compiles.
+#[repr(C)]
+pub struct NotTransparent2<'a, E = Option<Struct<i32>>> {
+    oo: &'a Option<Option<E>>,
+    os: &'a Option<Struct<E>>,
+    so: &'a Struct<Option<E>>,
+    ss: &'a Struct<Struct<E>>,
+
+    ooi: &'a Option<Option<i32>>,
+    osi: &'a Option<Struct<i32>>,
+    soi: &'a Struct<Option<i32>>,
+    ssi: &'a Struct<Struct<i32>>,
+}
+
+#[no_mangle]
+pub extern "C" fn root2(
+    a: FullyTransparent2<Transparent<Alias<i32>>>,
+    s: PartlyTransparent2<Option<Alias<i32>>>,
+    n: NotTransparent2<Struct<Option<i32>>>) {}
+
+#[repr(C)]
+pub struct FullyTransparentMany<E = Alias<Option<Transparent<NonNull<Transparent<i64>>>>>> {
+    ont: Option<NonNull<Transparent<E>>>,
+    otn: Option<Transparent<NonNull<E>>>,
+    ton: Transparent<Option<NonNull<E>>>,
+
+    // One erasable quadruple
+    totn: Transparent<Option<Transparent<NonNull<E>>>>,
+
+    onti: Option<NonNull<Transparent<i32>>>,
+    otni: Option<Transparent<NonNull<i32>>>,
+    toni: Transparent<Option<NonNull<i32>>>,
+
+    // One erasable quadruple
+    totni: Transparent<Option<Transparent<NonNull<i32>>>>,
+}
+
+#[repr(C)]
+pub struct PartlyTransparentMany<'a, E> {
+    // A few triples
+    tao: &'a Transparent<Alias<Option<E>>>,
+    toa: &'a Transparent<Option<Alias<E>>>,
+    ota: &'a Option<Transparent<Alias<E>>>,
+    tas: &'a Transparent<Alias<Struct<E>>>,
+    tsa: &'a Transparent<Struct<Alias<E>>>,
+    sta: &'a Struct<Transparent<Alias<E>>>,
+
+    // Two quadruples
+    toat: &'a Transparent<Option<Alias<Transparent<E>>>>,
+    tsat: &'a Transparent<Struct<Alias<Transparent<E>>>>,
+
+    // A few triples
+    taoi: &'a Transparent<Alias<Option<i32>>>,
+    toai: &'a Transparent<Option<Alias<i32>>>,
+    otai: &'a Option<Transparent<Alias<i32>>>,
+    tasi: &'a Transparent<Alias<Struct<i32>>>,
+    tsai: &'a Transparent<Struct<Alias<i32>>>,
+    stai: &'a Struct<Transparent<Alias<i32>>>,
+
+    // Two quadruples
+    toati: &'a Transparent<Option<Alias<Transparent<i32>>>>,
+    tsati: &'a Transparent<Struct<Alias<Transparent<i32>>>>,
+}
+
+#[no_mangle]
+pub extern "C" fn root_many(
+    a: FullyTransparentMany<Alias<Option<NonNull<i32>>>>,
+    b: PartlyTransparentMany<Alias<Option<Transparent<i32>>>>,
+) {}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -331,6 +331,18 @@ fn test_file(name: &'static str, filename: &'static str) {
     // Run tests in deduplication priority order. C++ compatibility tests are run first,
     // otherwise we would lose the C++ compiler run if they were deduplicated.
     let mut cbindgen_outputs = HashSet::new();
+
+    run_compile_test(
+        name,
+        test,
+        tmp_dir,
+        Language::Cxx,
+        /* cpp_compat = */ false,
+        None,
+        &mut HashSet::new(),
+        false,
+    );
+
     for cpp_compat in &[true, false] {
         for style in &[Style::Type, Style::Tag, Style::Both] {
             run_compile_test(
@@ -345,17 +357,6 @@ fn test_file(name: &'static str, filename: &'static str) {
             );
         }
     }
-
-    run_compile_test(
-        name,
-        test,
-        tmp_dir,
-        Language::Cxx,
-        /* cpp_compat = */ false,
-        None,
-        &mut HashSet::new(),
-        false,
-    );
 
     // `Style::Both` should be identical to `Style::Tag` for Cython.
     let mut cbindgen_outputs = HashSet::new();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -331,18 +331,6 @@ fn test_file(name: &'static str, filename: &'static str) {
     // Run tests in deduplication priority order. C++ compatibility tests are run first,
     // otherwise we would lose the C++ compiler run if they were deduplicated.
     let mut cbindgen_outputs = HashSet::new();
-
-    run_compile_test(
-        name,
-        test,
-        tmp_dir,
-        Language::Cxx,
-        /* cpp_compat = */ false,
-        None,
-        &mut HashSet::new(),
-        false,
-    );
-
     for cpp_compat in &[true, false] {
         for style in &[Style::Type, Style::Tag, Style::Both] {
             run_compile_test(
@@ -357,6 +345,17 @@ fn test_file(name: &'static str, filename: &'static str) {
             );
         }
     }
+
+    run_compile_test(
+        name,
+        test,
+        tmp_dir,
+        Language::Cxx,
+        /* cpp_compat = */ false,
+        None,
+        &mut HashSet::new(),
+        false,
+    );
 
     // `Style::Both` should be identical to `Style::Tag` for Cython.
     let mut cbindgen_outputs = HashSet::new();


### PR DESCRIPTION
Supersedes https://github.com/mozilla/cbindgen/pull/966

Following https://github.com/mozilla/cbindgen/issues/967, introduce `/// cbindgen:transparent-typedef` annotation that causes cbindgen to replace transparent structs and typedefs with their underlying type.

This allows the following:
```rust
/// cbindgen:transparent-typedef
#[repr(transparent)]
struct Foo(NonNull<i32>);

/// cbindgen:transparent-typedef
type Function = extern "C" fn(i: i32) -> i64;

type NullableFoo = Option<Foo>;
type NullableFunction = Option<Function>;
```
to export as
```c
typedef i32 *NullableFoo;
typedef int64_t (*NullableFunction)(int32_t);
```
instead of today's output:
```c++
template<typename T = void>
struct Option;

using Foo = int32_t*;
using Function = int64_t(*)(int32_t i);

using NullableFoo = Option<Foo>;
using NullableFunction = Option<Function>;
```