### PR TITLE
Improved generation of methods for traits implemented for objects

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -748,7 +748,6 @@ impl Parse {
 
         match (is_extern_c, exported_name) {
             (true, Some(exported_name)) => {
-                #[cfg(feature = "generate_traits_methods")]
                 let path = if let (Some(trait_name), Some(self_type)) = (trait_name, self_type) {
                     Path::new(format!("{exported_name}_{}s_{}", trait_name.to_string(), self_type.to_string()))
                 } else {


### PR DESCRIPTION
Development challenges arise when working with traits because if I want to ensure that my struct implements all possible methods from a trait, I encounter the problem described in the following code snippets:

```rust
pub trait DummyTrait {
    extern "C" fn dummy_method(self);
}

#[repr(C)]
struct DummyStruct {
    a: isize,
}

impl DummyTrait for DummyStruct {
    #[no_mangle]
    extern "C" fn dummy_method(mut self) {
        self.a = 1;
    }   
}

#[repr(C)]
struct DummyOtherStruct {
    b: isize,
}

impl DummyTrait for DummyOtherStruct {
    #[no_mangle]
    extern "C" fn dummy_method(mut self) {
        self.b = 1;
    }
}
```

```c
#include <stdarg.h>
#include <stdbool.h>
#include <stdint.h>
#include <stdlib.h>

typedef struct MyStruct {
  intptr_t a;
} DummyStruct;

typedef struct OtherStruct {
  intptr_t b;
} DummyOtherStruct;

void dummy_method(struct DummyStruct self);

void dummy_method(struct DummyOtherStruct self);
```

As we can see, we have two functions with the same name. Currently, this limitation can be worked around with somewhat inconvenient solutions, which is why I would like to propose my own solution that generates functions with more distinct names. An example of the generated code after applying my changes:

```c
#include <stdarg.h>
#include <stdbool.h>
#include <stdint.h>
#include <stdlib.h>

typedef struct MyStruct {
  intptr_t a;
} DummyStruct;

typedef struct OtherStruct {
  intptr_t b;
} DummyOtherStruct;

void dummy_method_DummyTraits_DummyStruct(struct DummyStruct self);

void dummy_method_DummyTraits_DummyOtherStruct(struct DummyOtherStruct self);
```

This code will compile. I have also created a separate branch named `traits-method-gen-feature`, where this functionality can be used as a feature.

P.S.: Apologies for any mistakes, as this is my first fork.