### PR TITLE
Upgrade heck to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tempfile = "3"
 toml = "0.8.8"
 proc-macro2 = "1.0.60"
 quote = "1"
-heck = "0.4"
+heck = "0.5"
 
 [dependencies.syn]
 version = "2.0.85"


### PR DESCRIPTION
The breaking change doesn't affect.

The change 0.4 to 0.5 is about `unicode` feature, which is not used in this project.