### PR TITLE
Github action: Add aarch64 to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,13 +14,20 @@ jobs:
       # someone with permissions to create a tag.
       contents: write
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Install stable
       uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: aarch64-unknown-linux-gnu
+
+    - name: Install cross libc
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libc6-arm64-cross gcc-11-aarch64-linux-gnu
 
     - name: semver
       run: |
@@ -30,10 +37,12 @@ jobs:
     - name: Build cbindgen
       run: |
         cargo +stable build --release
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc-11 cargo +stable build --target aarch64-unknown-linux-gnu --release
 
     - name: Strip cbindgen
       run: |
         strip target/release/cbindgen
+        aarch64-linux-gnu-strip target/aarch64-unknown-linux-gnu/release/cbindgen
 
     - name: Handle release data and files
       id: tagName
@@ -51,6 +60,8 @@ jobs:
     - name: Create a release
       run: |
         TAG=${{ steps.tagName.outputs.version }}
-        gh release create ${TAG} --title "${TAG}" --notes-file "CHANGES.txt" --draft 'target/release/cbindgen#cbindgen-ubuntu20.04'
+        cp target/release/cbindgen cbindgen-ubuntu22.04
+        cp target/aarch64-unknown-linux-gnu/release/cbindgen cbindgen-ubuntu22.04-aarch64
+        gh release create ${TAG} --title "${TAG}" --notes-file "CHANGES.txt" --draft cbindgen-ubuntu22.04 cbindgen-ubuntu22.04-aarch64
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
cross compiler package (gcc-11-aarch64-linux-gnu) only available starting with 22.04

Currently running test deploy here: https://github.com/NickeZ/cbindgen/actions/runs/14291327838/job/40052936519

---

edit: 
It does create the draft release, but only one artifact ends up there. Not sure what I'm doing wrong, I think the `gh release create` command should take multiple files.
 
```
HTTP 404: Not Found (https://uploads.github.com/repos/NickeZ/cbindgen/releases/210598162/assets?label=cbindgen-ubuntu22.04&name=cbindgen)
Error: Process completed with exit code 1.
```

---

edit2:
Fixed the issue and rebased: https://github.com/NickeZ/cbindgen/actions/runs/14409080964/job/40412556524