### PR TITLE
Fix parsing submodule dir for 2018 convention

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -263,7 +263,7 @@ impl Parser<'_> {
 
         let mod_dir = mod_path.parent().unwrap();
 
-        let is_mod_rs = depth == 0 || mod_path.ends_with("mod.rs");
+        let is_mod_rs = mod_path.ends_with("lib.rs") || mod_path.ends_with("mod.rs");
         let submod_dir = if is_mod_rs {
             mod_dir
         } else {


### PR DESCRIPTION
Fix for: https://github.com/mozilla/cbindgen/issues/1069