### PR TITLE
Add export config to expose all structs, enums or unions

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -605,6 +605,24 @@ include = ["MyOrphanStruct", "MyGreatTypeRename"]
 # default: []
 exclude = ["Bad"]
 
+# If this value is true, struct bindings will be generated even if they don't appear
+# in the public API.
+#
+# default: false
+structs = false
+
+# If this value is true, enum bindings will be generated even if they don't appear
+# in the public API.
+#
+# default: false
+enums = false
+
+# If this value is true, union bindings will be generated even if they don't appear
+# in the public API.
+#
+# default: false
+unions = false
+
 # A prefix to add before the name of every item
 # default: no prefix is added
 prefix = "CAPI_"

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -180,6 +180,24 @@ impl Builder {
     }
 
     #[allow(unused)]
+    pub fn export_structs(mut self, export: bool) -> Builder {
+        self.config.export.structs = export;
+        self
+    }
+
+    #[allow(unused)]
+    pub fn export_enums(mut self, export: bool) -> Builder {
+        self.config.export.enums = export;
+        self
+    }
+
+    #[allow(unused)]
+    pub fn export_unions(mut self, export: bool) -> Builder {
+        self.config.export.unions = export;
+        self
+    }
+
+    #[allow(unused)]
     pub fn rename_item<S: AsRef<str>>(mut self, from: S, to: S) -> Builder {
         self.config
             .export

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -327,6 +327,15 @@ pub struct ExportConfig {
     pub include: Vec<String>,
     /// A list of items to not include in the generated bindings
     pub exclude: Vec<String>,
+    /// Whether to export structs even if they're not part of the public
+    /// API.
+    pub structs: bool,
+    /// Whether to export enums even if they're not part of the public
+    /// API.
+    pub enums: bool,
+    /// Whether to export unions even if they're not part of the public
+    /// API.
+    pub unions: bool,
     /// Table of name conversions to apply to item names
     pub rename: HashMap<String, String>,
     /// Table of raw strings to prepend to the body of items.

--- a/tests/expectations/export_structs.compat.c
+++ b/tests/expectations/export_structs.compat.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} Foo;
+
+typedef struct {
+  Foo data;
+} Bar;

--- a/tests/expectations/export_structs.cpp
+++ b/tests/expectations/export_structs.cpp
@@ -1,0 +1,14 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+struct Foo {
+  int32_t x;
+  float y;
+};
+
+struct Bar {
+  Foo data;
+};

--- a/tests/expectations/export_structs.pyx
+++ b/tests/expectations/export_structs.pyx
@@ -1,0 +1,14 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef struct Foo:
+    int32_t x;
+    float y;
+
+  ctypedef struct Bar:
+    Foo data;

--- a/tests/expectations/export_structs_both.compat.c
+++ b/tests/expectations/export_structs_both.compat.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo {
+  int32_t x;
+  float y;
+} Foo;
+
+typedef struct Bar {
+  struct Foo data;
+} Bar;

--- a/tests/expectations/export_structs_exclude.compat.c
+++ b/tests/expectations/export_structs_exclude.compat.c
@@ -1,0 +1,9 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct {
+  int32_t x;
+  float y;
+} Foo;

--- a/tests/expectations/export_structs_exclude.cpp
+++ b/tests/expectations/export_structs_exclude.cpp
@@ -1,0 +1,10 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+struct Foo {
+  int32_t x;
+  float y;
+};

--- a/tests/expectations/export_structs_exclude.pyx
+++ b/tests/expectations/export_structs_exclude.pyx
@@ -1,0 +1,11 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef struct Foo:
+    int32_t x;
+    float y;

--- a/tests/expectations/export_structs_exclude_both.compat.c
+++ b/tests/expectations/export_structs_exclude_both.compat.c
@@ -1,0 +1,9 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Foo {
+  int32_t x;
+  float y;
+} Foo;

--- a/tests/expectations/export_structs_exclude_tag.compat.c
+++ b/tests/expectations/export_structs_exclude_tag.compat.c
@@ -1,0 +1,9 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo {
+  int32_t x;
+  float y;
+};

--- a/tests/expectations/export_structs_exclude_tag.pyx
+++ b/tests/expectations/export_structs_exclude_tag.pyx
@@ -1,0 +1,11 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef struct Foo:
+    int32_t x;
+    float y;

--- a/tests/expectations/export_structs_tag.compat.c
+++ b/tests/expectations/export_structs_tag.compat.c
@@ -1,0 +1,13 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct Foo {
+  int32_t x;
+  float y;
+};
+
+struct Bar {
+  struct Foo data;
+};

--- a/tests/expectations/export_structs_tag.pyx
+++ b/tests/expectations/export_structs_tag.pyx
@@ -1,0 +1,14 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  cdef struct Foo:
+    int32_t x;
+    float y;
+
+  cdef struct Bar:
+    Foo data;

--- a/tests/rust/export_structs.rs
+++ b/tests/rust/export_structs.rs
@@ -1,0 +1,10 @@
+#[repr(C)]
+struct Foo {
+    x: i32,
+    y: f32,
+}
+
+#[repr(C)]
+struct Bar {
+    data: Foo,
+}

--- a/tests/rust/export_structs.toml
+++ b/tests/rust/export_structs.toml
@@ -1,0 +1,2 @@
+[export]
+structs = true

--- a/tests/rust/export_structs_exclude.rs
+++ b/tests/rust/export_structs_exclude.rs
@@ -1,0 +1,10 @@
+#[repr(C)]
+struct Foo {
+    x: i32,
+    y: f32,
+}
+
+#[repr(C)]
+struct Bar {
+    data: Foo,
+}

--- a/tests/rust/export_structs_exclude.toml
+++ b/tests/rust/export_structs_exclude.toml
@@ -1,0 +1,3 @@
+[export]
+structs = true
+exclude = ["Bar"]


### PR DESCRIPTION
Currently, there is no simple way to instruct cbindgen to simply export all public structs, enums and/or unions, regardless of whether the items themselves appear in public functions or not. In order to do this, each item would need to be added manually to the `include` config item under `[export]`.

This change adds coarse-grained config items under `[export]` to simply export all structs, enums and/or unions. Items can further be excluded with the `exclude` config item under the same category.