### PR TITLE
Fix `clippy::uninlined_format_args`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,0 @@
-# Specify the minimum supported Rust version
-msrv = "1.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "A tool for generating C bindings to Rust code."
 keywords = ["bindings", "ffi", "code-generation"]
 categories = ["external-ffi-bindings", "development-tools::ffi"]
 repository = "https://github.com/mozilla/cbindgen"
-edition = "2018"
+edition = "2021"
 rust-version = "1.74"
 exclude = [
   "tests/profile.rs", # Test relies in a sub-crate, see https://github.com/rust-lang/cargo/issues/9017

--- a/src/bindgen/bindings.rs
+++ b/src/bindgen/bindings.rs
@@ -153,7 +153,7 @@ impl Bindings {
         let mut writer = BufWriter::new(File::create(symfile_path).unwrap());
         writeln!(&mut writer, "{{").expect("writing symbol file header failed");
         for symbol in self.dynamic_symbols_names() {
-            writeln!(&mut writer, "{};", symbol).expect("writing symbol failed");
+            writeln!(&mut writer, "{symbol};").expect("writing symbol failed");
         }
         write!(&mut writer, "}};").expect("writing symbol file footer failed");
     }

--- a/src/bindgen/builder.rs
+++ b/src/bindgen/builder.rs
@@ -272,7 +272,7 @@ impl Builder {
     #[allow(unused)]
     pub fn with_target_os_define(mut self, platform: &str, preprocessor_define: &str) -> Builder {
         self.config.defines.insert(
-            format!("target_os = {}", platform),
+            format!("target_os = {platform}"),
             preprocessor_define.to_owned(),
         );
         self
@@ -280,10 +280,9 @@ impl Builder {
 
     #[allow(unused)]
     pub fn with_define(mut self, key: &str, value: &str, preprocessor_define: &str) -> Builder {
-        self.config.defines.insert(
-            format!("{} = {}", key, value),
-            preprocessor_define.to_owned(),
-        );
+        self.config
+            .defines
+            .insert(format!("{key} = {value}"), preprocessor_define.to_owned());
         self
     }
 

--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -41,7 +41,7 @@ impl fmt::Display for Error {
         match self {
             Error::Io(ref err) => err.fmt(f),
             Error::Utf8(ref err) => err.fmt(f),
-            Error::Compile(ref err) => write!(f, "{}", err),
+            Error::Compile(ref err) => write!(f, "{err}"),
         }
     }
 }

--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -112,22 +112,19 @@ impl CDecl {
                 if is_const {
                     assert!(
                         self.type_qualifers.is_empty(),
-                        "error generating cdecl for {:?}",
-                        t
+                        "error generating cdecl for {t:?}"
                     );
                     "const".clone_into(&mut self.type_qualifers);
                 }
 
                 assert!(
                     self.type_name.is_empty(),
-                    "error generating cdecl for {:?}",
-                    t
+                    "error generating cdecl for {t:?}"
                 );
                 generic.export_name().clone_into(&mut self.type_name);
                 assert!(
                     self.type_generic_args.is_empty(),
-                    "error generating cdecl for {:?}",
-                    t
+                    "error generating cdecl for {t:?}"
                 );
                 generic.generics().clone_into(&mut self.type_generic_args);
                 self.type_ctype = generic.ctype().cloned();
@@ -136,16 +133,14 @@ impl CDecl {
                 if is_const {
                     assert!(
                         self.type_qualifers.is_empty(),
-                        "error generating cdecl for {:?}",
-                        t
+                        "error generating cdecl for {t:?}"
                     );
                     "const".clone_into(&mut self.type_qualifers);
                 }
 
                 assert!(
                     self.type_name.is_empty(),
-                    "error generating cdecl for {:?}",
-                    t
+                    "error generating cdecl for {t:?}"
                 );
                 self.type_name = p.to_repr_c(config).to_string();
             }
@@ -250,11 +245,11 @@ impl CDecl {
                     if config.language != Language::Cython {
                         if !is_nullable && !is_ref {
                             if let Some(attr) = &config.pointer.non_null_attribute {
-                                write!(out, "{} ", attr);
+                                write!(out, "{attr} ");
                             }
                         } else if is_nullable {
                             if let Some(attr) = &config.pointer.nullable_attribute {
-                                write!(out, "{} ", attr);
+                                write!(out, "{attr} ");
                             }
                         }
                     }
@@ -274,7 +269,7 @@ impl CDecl {
 
         // Write the identifier
         if let Some(ident) = ident {
-            write!(out, "{}", ident);
+            write!(out, "{ident}");
         }
 
         // Write the right part of declarators after the identifier
@@ -291,7 +286,7 @@ impl CDecl {
                     if last_was_pointer {
                         out.write(")");
                     }
-                    write!(out, "[{}]", constant);
+                    write!(out, "[{constant}]");
 
                     last_was_pointer = false;
                 }
@@ -365,7 +360,7 @@ impl CDecl {
 
                     if never_return && config.language != Language::Cython {
                         if let Some(ref no_return_attr) = config.function.no_return {
-                            out.write_fmt(format_args!(" {}", no_return_attr));
+                            out.write_fmt(format_args!(" {no_return_attr}"));
                         }
                     }
 

--- a/src/bindgen/config.rs
+++ b/src/bindgen/config.rs
@@ -42,7 +42,7 @@ impl FromStr for Language {
             "C" => Ok(Language::C),
             "cython" => Ok(Language::Cython),
             "Cython" => Ok(Language::Cython),
-            _ => Err(format!("Unrecognized Language: '{}'.", s)),
+            _ => Err(format!("Unrecognized Language: '{s}'.")),
         }
     }
 }
@@ -103,7 +103,7 @@ impl FromStr for LineEndingStyle {
             "lf" => Ok(Self::LF),
             "crlf" => Ok(Self::CRLF),
             "cr" => Ok(Self::CR),
-            _ => Err(format!("Unrecognized line ending style: '{}'.", s)),
+            _ => Err(format!("Unrecognized line ending style: '{s}'.")),
         }
     }
 }
@@ -126,7 +126,7 @@ impl FromStr for Braces {
             "same_line" => Ok(Braces::SameLine),
             "NextLine" => Ok(Braces::NextLine),
             "next_line" => Ok(Braces::NextLine),
-            _ => Err(format!("Unrecognized Braces: '{}'.", s)),
+            _ => Err(format!("Unrecognized Braces: '{s}'.")),
         }
     }
 }
@@ -152,7 +152,7 @@ impl FromStr for Layout {
             "vertical" => Ok(Layout::Vertical),
             "Auto" => Ok(Layout::Auto),
             "auto" => Ok(Layout::Auto),
-            _ => Err(format!("Unrecognized Layout: '{}'.", s)),
+            _ => Err(format!("Unrecognized Layout: '{s}'.")),
         }
     }
 }
@@ -180,7 +180,7 @@ impl FromStr for DocumentationStyle {
             "c++" => Ok(DocumentationStyle::Cxx),
             "doxy" => Ok(DocumentationStyle::Doxy),
             "auto" => Ok(DocumentationStyle::Auto),
-            _ => Err(format!("Unrecognized documentation style: '{}'.", s)),
+            _ => Err(format!("Unrecognized documentation style: '{s}'.")),
         }
     }
 }
@@ -201,7 +201,7 @@ impl FromStr for DocumentationLength {
         match s.to_lowercase().as_ref() {
             "short" => Ok(DocumentationLength::Short),
             "full" => Ok(DocumentationLength::Full),
-            _ => Err(format!("Unrecognized documentation style: '{}'.", s)),
+            _ => Err(format!("Unrecognized documentation style: '{s}'.")),
         }
     }
 }
@@ -253,7 +253,7 @@ impl FromStr for Style {
             "tag" => Ok(Style::Tag),
             "Type" => Ok(Style::Type),
             "type" => Ok(Style::Type),
-            _ => Err(format!("Unrecognized Style: '{}'.", s)),
+            _ => Err(format!("Unrecognized Style: '{s}'.")),
         }
     }
 }
@@ -287,7 +287,7 @@ impl FromStr for ItemType {
             "typedefs" => Typedefs,
             "opaque" => OpaqueItems,
             "functions" => Functions,
-            _ => return Err(format!("Unrecognized Style: '{}'.", s)),
+            _ => return Err(format!("Unrecognized Style: '{s}'.")),
         })
     }
 }
@@ -309,7 +309,7 @@ impl FromStr for SortKey {
         Ok(match &*s.to_lowercase() {
             "name" => Name,
             "none" => None,
-            _ => return Err(format!("Unrecognized sort option: '{}'.", s)),
+            _ => return Err(format!("Unrecognized sort option: '{s}'.")),
         })
     }
 }
@@ -752,7 +752,7 @@ impl FromStr for Profile {
         match s {
             "debug" | "Debug" => Ok(Profile::Debug),
             "release" | "Release" => Ok(Profile::Release),
-            _ => Err(format!("Unrecognized Profile: '{}'.", s)),
+            _ => Err(format!("Unrecognized Profile: '{s}'.")),
         }
     }
 }
@@ -1118,7 +1118,7 @@ impl Config {
         })?;
 
         let mut config = toml::from_str::<Config>(&config_text)
-            .map_err(|e| format!("Couldn't parse config file: {}.", e))?;
+            .map_err(|e| format!("Couldn't parse config file: {e}."))?;
         config.config_path = Some(StdPathBuf::from(file_name.as_ref()));
         Ok(config)
     }

--- a/src/bindgen/error.rs
+++ b/src/bindgen/error.rs
@@ -32,16 +32,14 @@ impl fmt::Display for Error {
         match *self {
             Error::CargoMetadata(ref path, ref error) => write!(
                 f,
-                "Couldn't execute `cargo metadata` with manifest {:?}: {:?}",
-                path, error
+                "Couldn't execute `cargo metadata` with manifest {path:?}: {error:?}"
             ),
             Error::CargoToml(ref path, ref error) => {
-                write!(f, "Couldn't load manifest file {:?}: {:?}", path, error)
+                write!(f, "Couldn't load manifest file {path:?}: {error:?}")
             }
             Error::CargoExpand(ref crate_name, ref error) => write!(
                 f,
-                "Parsing crate `{}`: couldn't run `cargo rustc -Zunpretty=expanded`: {:?}",
-                crate_name, error
+                "Parsing crate `{crate_name}`: couldn't run `cargo rustc -Zunpretty=expanded`: {error:?}"
             ),
             Error::ParseSyntaxError {
                 ref crate_name,
@@ -50,15 +48,13 @@ impl fmt::Display for Error {
             } => {
                 write!(
                     f,
-                    "Parsing crate `{}`:`{}`:\n{:?}",
-                    crate_name, src_path, error
+                    "Parsing crate `{crate_name}`:`{src_path}`:\n{error:?}"
                 )?;
 
                 if !src_path.is_empty() {
                     write!(
                         f,
-                        "\nTry running `rustc -Z parse-crate-root-only {}` to see a nicer error message",
-                        src_path,
+                        "\nTry running `rustc -Z parse-crate-root-only {src_path}` to see a nicer error message",
                     )?
                 }
                 Ok(())
@@ -68,8 +64,7 @@ impl fmt::Display for Error {
                 ref src_path,
             } => write!(
                 f,
-                "Parsing crate `{}`: cannot open file `{}`.",
-                crate_name, src_path
+                "Parsing crate `{crate_name}`: cannot open file `{src_path}`."
             ),
         }
     }

--- a/src/bindgen/ir/annotation.rs
+++ b/src/bindgen/ir/annotation.rs
@@ -96,7 +96,7 @@ impl AnnotationSet {
             DeprecatedNoteKind::Struct => &config.structure.deprecated_with_note,
         }
         .as_ref()?;
-        Some(Cow::Owned(format.replace("{}", &format!("{:?}", note))))
+        Some(Cow::Owned(format.replace("{}", &format!("{note:?}"))))
     }
 
     pub fn load(attrs: &[syn::Attribute]) -> Result<AnnotationSet, String> {
@@ -128,7 +128,7 @@ impl AnnotationSet {
             let parts: Vec<&str> = annotation.split('=').map(|x| x.trim()).collect();
 
             if parts.len() > 2 {
-                return Err(format!("Couldn't parse {}.", line));
+                return Err(format!("Couldn't parse {line}."));
             }
 
             // Grab the name that this annotation is modifying

--- a/src/bindgen/ir/cfg.rs
+++ b/src/bindgen/ir/cfg.rs
@@ -54,15 +54,15 @@ pub enum Cfg {
 impl fmt::Display for Cfg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Cfg::Boolean(key) => write!(f, "{}", key),
-            Cfg::Named(key, value) => write!(f, "{} = {:?}", key, value),
+            Cfg::Boolean(key) => write!(f, "{key}"),
+            Cfg::Named(key, value) => write!(f, "{key} = {value:?}"),
             Cfg::Any(cfgs) => {
                 write!(f, "any(")?;
                 for (index, cfg) in cfgs.iter().enumerate() {
                     if index > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}", cfg)?;
+                    write!(f, "{cfg}")?;
                 }
                 write!(f, ")")
             }
@@ -72,11 +72,11 @@ impl fmt::Display for Cfg {
                     if index > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}", cfg)?;
+                    write!(f, "{cfg}")?;
                 }
                 write!(f, ")")
             }
-            Cfg::Not(cfg) => write!(f, "not({})", cfg),
+            Cfg::Not(cfg) => write!(f, "not({cfg})"),
         }
     }
 }
@@ -276,10 +276,10 @@ impl Condition {
         match *self {
             Condition::Define(ref define) => {
                 if config.language == Language::Cython {
-                    write!(out, "{}", define);
+                    write!(out, "{define}");
                 } else {
                     out.write("defined(");
-                    write!(out, "{}", define);
+                    write!(out, "{define}");
                     out.write(")");
                 }
             }

--- a/src/bindgen/ir/constant.rs
+++ b/src/bindgen/ir/constant.rs
@@ -76,7 +76,7 @@ pub(crate) fn to_known_assoc_constant(associated_to: &Path, name: &str) -> Optio
         },
         _ => return None,
     };
-    Some(format!("{}_{}", prefix, name))
+    Some(format!("{prefix}_{name}"))
 }
 
 #[derive(Debug, Clone)]
@@ -333,8 +333,7 @@ impl Literal {
                     syn::BinOp::ShrAssign(..) => ">>=",
                     currently_unknown => {
                         return Err(format!(
-                            "unsupported binary operator: {:?}",
-                            currently_unknown
+                            "unsupported binary operator: {currently_unknown:?}"
                         ))
                     }
                 };
@@ -351,7 +350,7 @@ impl Literal {
                     syn::Lit::Byte(ref value) => Ok(Literal::Expr(format!("{}", value.value()))),
                     syn::Lit::Char(ref value) => Ok(Literal::Expr(match value.value() as u32 {
                         0..=255 => format!("'{}'", value.value().escape_default()),
-                        other_code => format!(r"U'\U{:08X}'", other_code),
+                        other_code => format!(r"U'\U{other_code:08X}'"),
                     })),
                     syn::Lit::Int(ref value) => {
                         let suffix = match value.suffix() {
@@ -467,7 +466,7 @@ impl Literal {
                             name: path.segments[1].ident.to_string(),
                         }
                     }
-                    _ => return Err(format!("Unsupported path expression. {:?}", path)),
+                    _ => return Err(format!("Unsupported path expression. {path:?}")),
                 })
             }
 
@@ -729,12 +728,12 @@ impl Constant {
                 }
 
                 language_backend.write_type(out, &self.ty);
-                write!(out, " {} = ", name);
+                write!(out, " {name} = ");
                 language_backend.write_literal(out, value);
                 write!(out, ";");
             }
             Language::Cxx | Language::C => {
-                write!(out, "#define {} ", name);
+                write!(out, "#define {name} ");
                 language_backend.write_literal(out, value);
             }
             Language::Cython => {
@@ -742,7 +741,7 @@ impl Constant {
                 language_backend.write_type(out, &self.ty);
                 // For extern Cython declarations the initializer is ignored,
                 // but still useful as documentation, so we write it as a comment.
-                write!(out, " {} # = ", name);
+                write!(out, " {name} # = ");
                 language_backend.write_literal(out, value);
             }
         }

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -119,7 +119,7 @@ impl EnumVariant {
 
             if inline_tag_field {
                 res.push(Field::from_name_and_type(
-                    inline_name.map_or_else(|| "tag".to_string(), |name| format!("{}_tag", name)),
+                    inline_name.map_or_else(|| "tag".to_string(), |name| format!("{name}_tag")),
                     Type::Path(GenericPath::new(Path::new("Tag"), vec![])),
                 ));
             }
@@ -669,15 +669,15 @@ impl Enum {
                         .annotations
                         .deprecated_note(config, DeprecatedNoteKind::Enum)
                     {
-                        write!(out, " {}", note);
+                        write!(out, " {note}");
                     }
-                    write!(out, " {}", tag_name);
+                    write!(out, " {tag_name}");
 
                     if config.cpp_compatible_c() {
                         out.new_line();
                         out.write("#ifdef __cplusplus");
                         out.new_line();
-                        write!(out, "  : {}", prim);
+                        write!(out, "  : {prim}");
                         out.new_line();
                         out.write("#endif // __cplusplus");
                         out.new_line();
@@ -691,10 +691,10 @@ impl Enum {
                         .annotations
                         .deprecated_note(config, DeprecatedNoteKind::Enum)
                     {
-                        write!(out, " {}", note);
+                        write!(out, " {note}");
                     }
                     if config.style.generate_tag() {
-                        write!(out, " {}", tag_name);
+                        write!(out, " {tag_name}");
                     }
                 }
             }
@@ -707,7 +707,7 @@ impl Enum {
 
                 if self.annotations.must_use(config) {
                     if let Some(ref anno) = config.enumeration.must_use {
-                        write!(out, " {}", anno)
+                        write!(out, " {anno}")
                     }
                 }
 
@@ -715,12 +715,12 @@ impl Enum {
                     .annotations
                     .deprecated_note(config, DeprecatedNoteKind::Enum)
                 {
-                    write!(out, " {}", note);
+                    write!(out, " {note}");
                 }
 
-                write!(out, " {}", tag_name);
+                write!(out, " {tag_name}");
                 if let Some(prim) = size {
-                    write!(out, " : {}", prim);
+                    write!(out, " : {prim}");
                 }
             }
             Language::Cython => {
@@ -746,7 +746,7 @@ impl Enum {
         // Close the tag enum.
         if config.language == Language::C && size.is_none() && config.style.generate_typedef() {
             out.close_brace(false);
-            write!(out, " {};", tag_name);
+            write!(out, " {tag_name};");
         } else {
             out.close_brace(true);
         }
@@ -792,7 +792,7 @@ impl Enum {
 
         if self.annotations.must_use(config) {
             if let Some(ref anno) = config.structure.must_use {
-                write!(out, " {}", anno);
+                write!(out, " {anno}");
             }
         }
 
@@ -800,7 +800,7 @@ impl Enum {
             .annotations
             .deprecated_note(config, DeprecatedNoteKind::Struct)
         {
-            write!(out, " {} ", note);
+            write!(out, " {note} ");
         }
 
         if config.language != Language::C || config.style.generate_tag() {
@@ -870,7 +870,7 @@ impl Enum {
             out.write("enum ");
         }
 
-        write!(out, "{} tag;", tag_name);
+        write!(out, "{tag_name} tag;");
 
         if wrap_tag {
             out.close_brace(true);
@@ -1003,7 +1003,7 @@ impl Enum {
                 );
                 out.new_line();
             }
-            write!(out, "switch ({})", instance);
+            write!(out, "switch ({instance})");
             out.open_brace();
             let vec: Vec<_> = self
                 .variants
@@ -1019,12 +1019,12 @@ impl Enum {
                 language_backend,
                 &vec[..],
                 ListType::Join(""),
-                |_, out, s| write!(out, "{}", s),
+                |_, out, s| write!(out, "{s}"),
             );
             out.close_brace(false);
             out.new_line();
 
-            write!(out, "return {};", stream);
+            write!(out, "return {stream};");
             out.close_brace(false);
 
             if has_data {
@@ -1052,7 +1052,7 @@ impl Enum {
                 );
                 out.new_line();
 
-                write!(out, "switch ({}.tag)", instance);
+                write!(out, "switch ({instance}.tag)");
                 out.open_brace();
                 let vec: Vec<_> = self
                     .variants
@@ -1085,12 +1085,12 @@ impl Enum {
                     language_backend,
                     &vec[..],
                     ListType::Join(""),
-                    |_, out, s| write!(out, "{}", s),
+                    |_, out, s| write!(out, "{s}"),
                 );
                 out.close_brace(false);
                 out.new_line();
 
-                write!(out, "return {};", stream);
+                write!(out, "return {stream};");
                 out.close_brace(false);
             }
         }
@@ -1270,7 +1270,7 @@ impl Enum {
                     out.open_brace();
                     write!(out, "{}(Is{}());", assert_name, variant.export_name);
                     out.new_line();
-                    write!(out, "return {}", member_name);
+                    write!(out, "return {member_name}");
                     if inline_casts {
                         write!(out, "._0");
                     }
@@ -1313,7 +1313,7 @@ impl Enum {
                 self.export_name, other
             );
             out.open_brace();
-            write!(out, "if (tag != {}.tag)", other);
+            write!(out, "if (tag != {other}.tag)");
             out.open_brace();
             write!(out, "return false;");
             out.close_brace(false);
@@ -1364,7 +1364,7 @@ impl Enum {
                     self.export_name, other
                 );
                 out.open_brace();
-                write!(out, "return !(*this == {});", other);
+                write!(out, "return !(*this == {other});");
                 out.close_brace(false);
             }
         }
@@ -1438,7 +1438,7 @@ impl Enum {
                 self.export_name, self.export_name, other
             );
             out.new_line();
-            write!(out, " : tag({}.tag)", other);
+            write!(out, " : tag({other}.tag)");
             out.open_brace();
             write!(out, "switch (tag)");
             out.open_brace();
@@ -1484,7 +1484,7 @@ impl Enum {
                     self.export_name, self.export_name, other
                 );
                 out.open_brace();
-                write!(out, "if (this != &{})", other);
+                write!(out, "if (this != &{other})");
                 out.open_brace();
                 write!(out, "this->~{}();", self.export_name);
                 out.new_line();

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -90,7 +90,7 @@ impl Function {
                 if !self.path.name().starts_with(&type_name) {
                     return Some(self.path.to_string());
                 }
-                (format!("{}.", type_name), type_name)
+                (format!("{type_name}."), type_name)
             }
             None => ("".to_string(), "".to_string()),
         };
@@ -108,7 +108,7 @@ impl Function {
             }
             items.join("")
         };
-        Some(format!("{}{}({})", type_prefix, item_name, item_args))
+        Some(format!("{type_prefix}{item_name}({item_args})"))
     }
 
     pub fn path(&self) -> &Path {
@@ -265,8 +265,7 @@ impl SynFnArgHelpers for syn::FnArg {
                     }
                     _ => {
                         return Err(format!(
-                            "Parameter has an unsupported argument name: {:?}",
-                            pat
+                            "Parameter has an unsupported argument name: {pat:?}"
                         ))
                     }
                 };

--- a/src/bindgen/ir/generic_path.rs
+++ b/src/bindgen/ir/generic_path.rs
@@ -62,7 +62,7 @@ impl GenericParam {
             }) => match Type::load(ty)? {
                 None => {
                     // A type that evaporates, like PhantomData.
-                    Err(format!("unsupported const generic type: {:?}", ty))
+                    Err(format!("unsupported const generic type: {ty:?}"))
                 }
                 Some(ty) => Ok(Some(GenericParam {
                     name: Path::new(ident.unraw().to_string()),
@@ -308,8 +308,7 @@ impl GenericPath {
     pub fn load(path: &syn::Path) -> Result<Self, String> {
         assert!(
             !path.segments.is_empty(),
-            "{:?} doesn't have any segments",
-            path
+            "{path:?} doesn't have any segments"
         );
         let last_segment = path.segments.last().unwrap();
         let name = last_segment.ident.unraw().to_string();
@@ -330,7 +329,7 @@ impl GenericPath {
                 syn::GenericArgument::Const(ref x) => {
                     Ok(Some(GenericArgument::Const(ConstExpr::load(x)?)))
                 }
-                _ => Err(format!("can't handle generic argument {:?}", x)),
+                _ => Err(format!("can't handle generic argument {x:?}")),
             })?,
             syn::PathArguments::Parenthesized(_) => {
                 return Err("Path contains parentheses.".to_owned());

--- a/src/bindgen/ir/repr.rs
+++ b/src/bindgen/ir/repr.rs
@@ -123,8 +123,7 @@ impl Repr {
                     // Only permit a single alignment-setting repr.
                     if let Some(old_align) = repr.align {
                         return Err(format!(
-                            "Conflicting #[repr(align(...))] type hints {:?} and {:?}.",
-                            old_align, align
+                            "Conflicting #[repr(align(...))] type hints {old_align:?} and {align:?}."
                         ));
                     }
                     repr.align = Some(align);
@@ -134,11 +133,11 @@ impl Repr {
                     // Must be a positive integer.
                     let align = match arg.parse::<u64>() {
                         Ok(align) => align,
-                        Err(_) => return Err(format!("Non-unsigned #[repr(align({}))].", arg)),
+                        Err(_) => return Err(format!("Non-unsigned #[repr(align({arg}))].")),
                     };
                     // Must be a power of 2.
                     if !align.is_power_of_two() || align == 0 {
-                        return Err(format!("Invalid alignment to #[repr(align({}))].", align));
+                        return Err(format!("Invalid alignment to #[repr(align({align}))]."));
                     }
                     // Only permit a single alignment-setting repr.
                     if let Some(old_align) = repr.align {
@@ -152,9 +151,9 @@ impl Repr {
                     continue;
                 }
                 (path, arg) => match arg {
-                    None => return Err(format!("Unsupported #[repr({})].", path)),
+                    None => return Err(format!("Unsupported #[repr({path})].")),
                     Some(arg) => {
-                        return Err(format!("Unsupported #[repr({}({}))].", path, arg));
+                        return Err(format!("Unsupported #[repr({path}({arg}))]."));
                     }
                 },
             };
@@ -164,8 +163,7 @@ impl Repr {
             };
             if let Some(old_ty) = repr.ty {
                 return Err(format!(
-                    "Conflicting #[repr(...)] type hints {:?} and {:?}.",
-                    old_ty, ty
+                    "Conflicting #[repr(...)] type hints {old_ty:?} and {ty:?}."
                 ));
             }
             repr.ty = Some(ty);

--- a/src/bindgen/ir/structure.rs
+++ b/src/bindgen/ir/structure.rs
@@ -84,7 +84,7 @@ impl Struct {
                     if let Some(mut ty) = Type::load(&field.ty)? {
                         ty.replace_self_with(&path);
                         out.push(Field {
-                            name: format!("{}", current),
+                            name: format!("{current}"),
                             ty,
                             cfg: Cfg::load(&field.attrs),
                             annotations: AnnotationSet::load(&field.attrs)?,
@@ -258,7 +258,7 @@ impl Struct {
             other
         );
         out.open_brace();
-        write!(out, "*this = (*this {} {});", operator, other);
+        write!(out, "*this = (*this {operator} {other});");
         out.new_line();
         write!(out, "return *this;");
         out.close_brace(false);

--- a/src/bindgen/ir/ty.rs
+++ b/src/bindgen/ir/ty.rs
@@ -262,7 +262,7 @@ impl ConstExpr {
                     syn::Lit::Int(ref len) => len.base10_digits().to_string(),
                     syn::Lit::Byte(ref byte) => u8::to_string(&byte.value()),
                     syn::Lit::Char(ref ch) => u32::to_string(&ch.value().into()),
-                    _ => return Err(format!("can't handle const expression {:?}", lit)),
+                    _ => return Err(format!("can't handle const expression {lit:?}")),
                 };
                 Ok(ConstExpr::Value(val))
             }
@@ -271,7 +271,7 @@ impl ConstExpr {
                 Ok(ConstExpr::Name(generic_path.export_name().to_owned()))
             }
             syn::Expr::Cast(ref cast) => Ok(ConstExpr::load(&cast.expr)?),
-            _ => Err(format!("can't handle const expression {:?}", expr)),
+            _ => Err(format!("can't handle const expression {expr:?}")),
         }
     }
 
@@ -459,7 +459,7 @@ impl Type {
             syn::Type::Verbatim(ref tokens) if tokens.to_string() == "..." => {
                 Type::Primitive(PrimitiveType::VaList)
             }
-            _ => return Err(format!("Unsupported type: {:?}", ty)),
+            _ => return Err(format!("Unsupported type: {ty:?}")),
         };
 
         Ok(Some(converted))

--- a/src/bindgen/language_backend/clike.rs
+++ b/src/bindgen/language_backend/clike.rs
@@ -31,7 +31,7 @@ impl<'a> CLikeLanguageBackend<'a> {
             .annotations()
             .deprecated_note(self.config, DeprecatedNoteKind::EnumVariant)
         {
-            write!(out, " {}", note);
+            write!(out, " {note}");
         }
         if let Some(discriminant) = &u.discriminant {
             out.write(" = ");
@@ -99,9 +99,9 @@ impl<'a> CLikeLanguageBackend<'a> {
         for namespace in namespaces {
             out.new_line();
             if open {
-                write!(out, "namespace {} {{", namespace)
+                write!(out, "namespace {namespace} {{")
             } else {
-                write!(out, "}}  // namespace {}", namespace)
+                write!(out, "}}  // namespace {namespace}")
             }
         }
 
@@ -146,7 +146,7 @@ impl<'a> CLikeLanguageBackend<'a> {
                 .map(|(field, renamed)| {
                     Field::from_name_and_type(
                         // const-ref args to constructor
-                        format!("const& {}", renamed),
+                        format!("const& {renamed}"),
                         field.ty.clone(),
                     )
                 })
@@ -162,7 +162,7 @@ impl<'a> CLikeLanguageBackend<'a> {
                 .map(|(field, renamed)| format!("{}({})", field.name, renamed))
                 .collect();
             out.write_vertical_source_list(self, &vec[..], ListType::Join(","), |_, out, s| {
-                write!(out, "{}", s)
+                write!(out, "{s}")
             });
             out.new_line();
             write!(out, "{{}}");
@@ -192,7 +192,7 @@ impl<'a> CLikeLanguageBackend<'a> {
             };
 
             out.new_line();
-            write!(out, "{}explicit operator bool() const", constexpr_prefix);
+            write!(out, "{constexpr_prefix}explicit operator bool() const");
             out.open_brace();
             write!(out, "return !!{bits};");
             out.close_brace(false);
@@ -245,7 +245,7 @@ impl<'a> CLikeLanguageBackend<'a> {
                 instance,
             );
             out.open_brace();
-            write!(out, "return {} << \"{{ \"", stream);
+            write!(out, "return {stream} << \"{{ \"");
             let vec: Vec<_> = s
                 .fields
                 .iter()
@@ -255,7 +255,7 @@ impl<'a> CLikeLanguageBackend<'a> {
                 self,
                 &vec[..],
                 ListType::Join(" << \", \""),
-                |_, out, s| write!(out, "{}", s),
+                |_, out, s| write!(out, "{s}"),
             );
             out.write(" << \" }\";");
             out.close_brace(false);
@@ -341,19 +341,19 @@ impl<'a> CLikeLanguageBackend<'a> {
 impl LanguageBackend for CLikeLanguageBackend<'_> {
     fn write_headers<W: Write>(&self, out: &mut SourceWriter<W>, package_version: &str) {
         if self.config.package_version {
-            write!(out, "/* Package version: {} */", package_version);
+            write!(out, "/* Package version: {package_version} */");
             out.new_line();
         }
         if let Some(ref f) = self.config.header {
             out.new_line_if_not_start();
-            write!(out, "{}", f);
+            write!(out, "{f}");
             out.new_line();
         }
         if let Some(f) = self.config.include_guard() {
             out.new_line_if_not_start();
-            write!(out, "#ifndef {}", f);
+            write!(out, "#ifndef {f}");
             out.new_line();
-            write!(out, "#define {}", f);
+            write!(out, "#define {f}");
             out.new_line();
         }
         if self.config.pragma_once {
@@ -372,7 +372,7 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
         }
         if let Some(ref f) = self.config.autogen_warning {
             out.new_line_if_not_start();
-            write!(out, "{}", f);
+            write!(out, "{f}");
             out.new_line();
         }
 
@@ -430,17 +430,17 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
         }
 
         for include in self.config.sys_includes() {
-            write!(out, "#include <{}>", include);
+            write!(out, "#include <{include}>");
             out.new_line();
         }
 
         for include in self.config.includes() {
-            write!(out, "#include \"{}\"", include);
+            write!(out, "#include \"{include}\"");
             out.new_line();
         }
 
         if let Some(ref line) = self.config.after_includes {
-            write!(out, "{}", line);
+            write!(out, "{line}");
             out.new_line();
         }
     }
@@ -457,9 +457,9 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
         if let Some(f) = self.config.include_guard() {
             out.new_line_if_not_start();
             if self.config.language == Language::C {
-                write!(out, "#endif  /* {} */", f);
+                write!(out, "#endif  /* {f} */");
             } else {
-                write!(out, "#endif  // {}", f);
+                write!(out, "#endif  // {f}");
             }
             out.new_line();
         }
@@ -566,12 +566,12 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
             match align {
                 ReprAlign::Packed => {
                     if let Some(ref anno) = self.config.layout.packed {
-                        write!(out, " {}", anno);
+                        write!(out, " {anno}");
                     }
                 }
                 ReprAlign::Align(n) => {
                     if let Some(ref anno) = self.config.layout.aligned_n {
-                        write!(out, " {}({})", anno, n);
+                        write!(out, " {anno}({n})");
                     }
                 }
             }
@@ -579,7 +579,7 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
 
         if s.annotations.must_use(self.config) {
             if let Some(ref anno) = self.config.structure.must_use {
-                write!(out, " {}", anno);
+                write!(out, " {anno}");
             }
         }
 
@@ -587,7 +587,7 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
             .annotations
             .deprecated_note(self.config, DeprecatedNoteKind::Struct)
         {
-            write!(out, " {}", note);
+            write!(out, " {note}");
         }
 
         if self.config.language != Language::C || self.config.style.generate_tag() {
@@ -664,12 +664,12 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
             match align {
                 ReprAlign::Packed => {
                     if let Some(ref anno) = self.config.layout.packed {
-                        write!(out, " {}", anno);
+                        write!(out, " {anno}");
                     }
                 }
                 ReprAlign::Align(n) => {
                     if let Some(ref anno) = self.config.layout.aligned_n {
-                        write!(out, " {}({})", anno, n);
+                        write!(out, " {anno}({n})");
                     }
                 }
             }
@@ -818,7 +818,7 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
                 DocumentationStyle::Auto => unreachable!(), // Auto case should always be covered
             }
 
-            write!(out, "{}", line);
+            write!(out, "{line}");
             out.new_line();
         }
 
@@ -839,14 +839,14 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
 
     fn write_literal<W: Write>(&mut self, out: &mut SourceWriter<W>, l: &Literal) {
         match l {
-            Literal::Expr(v) => write!(out, "{}", v),
+            Literal::Expr(v) => write!(out, "{v}"),
             Literal::Path {
                 ref associated_to,
                 ref name,
             } => {
                 if let Some((ref path, ref export_name)) = associated_to {
                     if let Some(known) = to_known_assoc_constant(path, name) {
-                        return write!(out, "{}", known);
+                        return write!(out, "{known}");
                     }
                     let path_separator = if self.config.language == Language::C {
                         "_"
@@ -855,9 +855,9 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
                     } else {
                         "_"
                     };
-                    write!(out, "{}{}", export_name, path_separator)
+                    write!(out, "{export_name}{path_separator}")
                 }
-                write!(out, "{}", name)
+                write!(out, "{name}")
             }
             Literal::FieldAccess {
                 ref base,
@@ -865,10 +865,10 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
             } => {
                 write!(out, "(");
                 self.write_literal(out, base);
-                write!(out, ").{}", field);
+                write!(out, ").{field}");
             }
             Literal::PostfixUnaryOp { op, ref value } => {
-                write!(out, "{}", op);
+                write!(out, "{op}");
                 self.write_literal(out, value);
             }
             Literal::BinOp {
@@ -878,7 +878,7 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
             } => {
                 write!(out, "(");
                 self.write_literal(out, left);
-                write!(out, " {} ", op);
+                write!(out, " {op} ");
                 self.write_literal(out, right);
                 write!(out, ")");
             }
@@ -897,9 +897,9 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
                 let is_constexpr = self.config.language == Language::Cxx
                     && (self.config.constant.allow_static_const || allow_constexpr);
                 if self.config.language == Language::C {
-                    write!(out, "({})", export_name);
+                    write!(out, "({export_name})");
                 } else {
-                    write!(out, "{}", export_name);
+                    write!(out, "{export_name}");
                 }
 
                 write!(out, "{{");
@@ -919,7 +919,7 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
                             condition.write_before(self.config, out);
                             // TODO: Some C++ versions (c++20?) now support designated
                             // initializers, consider generating them.
-                            write!(out, "/* .{} = */ ", ordered_key);
+                            write!(out, "/* .{ordered_key} = */ ");
                             self.write_literal(out, &lit.value);
                             if i + 1 != ordered_fields.len() {
                                 write!(out, ",");
@@ -933,9 +933,9 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
                             if self.config.language == Language::Cxx {
                                 // TODO: Some C++ versions (c++20?) now support designated
                                 // initializers, consider generating them.
-                                write!(out, "/* .{} = */ ", ordered_key);
+                                write!(out, "/* .{ordered_key} = */ ");
                             } else {
-                                write!(out, ".{} = ", ordered_key);
+                                write!(out, ".{ordered_key} = ");
                             }
                             self.write_literal(out, &lit.value);
                         }
@@ -965,7 +965,7 @@ impl LanguageBackend for CLikeLanguageBackend<'_> {
                 if let Some(ref using_namespaces) = b.config.using_namespaces {
                     for namespace in using_namespaces {
                         out.new_line();
-                        write!(out, "using namespace {};", namespace);
+                        write!(out, "using namespace {namespace};");
                     }
                     out.new_line();
                 }

--- a/src/bindgen/language_backend/cython.rs
+++ b/src/bindgen/language_backend/cython.rs
@@ -44,12 +44,12 @@ impl<'a> CythonLanguageBackend<'a> {
 impl LanguageBackend for CythonLanguageBackend<'_> {
     fn write_headers<W: Write>(&self, out: &mut SourceWriter<W>, package_version: &str) {
         if self.config.package_version {
-            write!(out, "''' Package version: {} '''", package_version);
+            write!(out, "''' Package version: {package_version} '''");
             out.new_line();
         }
         if let Some(ref f) = self.config.header {
             out.new_line_if_not_start();
-            write!(out, "{}", f);
+            write!(out, "{f}");
             out.new_line();
         }
 
@@ -64,7 +64,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
         }
         if let Some(ref f) = &self.config.autogen_warning {
             out.new_line_if_not_start();
-            write!(out, "{}", f);
+            write!(out, "{f}");
             out.new_line();
         }
 
@@ -99,7 +99,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
         }
 
         if let Some(ref line) = &self.config.after_includes {
-            write!(out, "{}", line);
+            write!(out, "{line}");
             out.new_line();
         }
     }
@@ -107,7 +107,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
     fn open_namespaces<W: Write>(&mut self, out: &mut SourceWriter<W>) {
         out.new_line();
         let header = &self.config.cython.header.as_deref().unwrap_or("*");
-        write!(out, "cdef extern from {}", header);
+        write!(out, "cdef extern from {header}");
         out.open_brace();
     }
 
@@ -180,7 +180,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
 
         if s.annotations.must_use(self.config) {
             if let Some(ref anno) = &self.config.structure.must_use {
-                write!(out, " {}", anno);
+                write!(out, " {anno}");
             }
         }
 
@@ -188,7 +188,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
             .annotations
             .deprecated_note(self.config, DeprecatedNoteKind::Struct)
         {
-            write!(out, " {}", note);
+            write!(out, " {note}");
         }
 
         write!(out, " {}", s.export_name());
@@ -328,7 +328,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
 
         // Cython uses Python-style comments, so `documentation_style` is not relevant.
         for line in &d.doc_comment[..end] {
-            write!(out, "#{}", line);
+            write!(out, "#{line}");
             out.new_line();
         }
     }
@@ -338,7 +338,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
             Literal::Expr(v) => match &**v {
                 "true" => write!(out, "True"),
                 "false" => write!(out, "False"),
-                v => write!(out, "{}", v),
+                v => write!(out, "{v}"),
             },
             Literal::Path {
                 ref associated_to,
@@ -346,11 +346,11 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
             } => {
                 if let Some((ref path, ref export_name)) = associated_to {
                     if let Some(known) = to_known_assoc_constant(path, name) {
-                        return write!(out, "{}", known);
+                        return write!(out, "{known}");
                     }
-                    write!(out, "{}_", export_name)
+                    write!(out, "{export_name}_")
                 }
-                write!(out, "{}", name)
+                write!(out, "{name}")
             }
             Literal::FieldAccess {
                 ref base,
@@ -358,10 +358,10 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
             } => {
                 write!(out, "(");
                 self.write_literal(out, base);
-                write!(out, ").{}", field);
+                write!(out, ").{field}");
             }
             Literal::PostfixUnaryOp { op, ref value } => {
-                write!(out, "{}", op);
+                write!(out, "{op}");
                 self.write_literal(out, value);
             }
             Literal::BinOp {
@@ -371,7 +371,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
             } => {
                 write!(out, "(");
                 self.write_literal(out, left);
-                write!(out, " {} ", op);
+                write!(out, " {op} ");
                 self.write_literal(out, right);
                 write!(out, ")");
             }
@@ -386,7 +386,7 @@ impl LanguageBackend for CythonLanguageBackend<'_> {
                 fields,
                 path,
             } => {
-                write!(out, "<{}>", export_name);
+                write!(out, "<{export_name}>");
 
                 write!(out, "{{ ");
                 let mut is_first_field = true;

--- a/src/bindgen/language_backend/mod.rs
+++ b/src/bindgen/language_backend/mod.rs
@@ -75,12 +75,12 @@ pub trait LanguageBackend: Sized {
             out.write("extern ");
         } else {
             if let Some(ref prefix) = prefix {
-                write!(out, "{}", prefix);
+                write!(out, "{prefix}");
                 write_space(layout, out);
             }
             if func.annotations.must_use(config) {
                 if let Some(ref anno) = config.function.must_use {
-                    write!(out, "{}", anno);
+                    write!(out, "{anno}");
                     write_space(layout, out);
                 }
             }
@@ -88,7 +88,7 @@ pub trait LanguageBackend: Sized {
                 .annotations
                 .deprecated_note(config, DeprecatedNoteKind::Function)
             {
-                write!(out, "{}", note);
+                write!(out, "{note}");
                 write_space(layout, out);
             }
         }
@@ -97,14 +97,14 @@ pub trait LanguageBackend: Sized {
         if !func.extern_decl {
             if let Some(ref postfix) = postfix {
                 write_space(layout, out);
-                write!(out, "{}", postfix);
+                write!(out, "{postfix}");
             }
         }
 
         if let Some(ref swift_name_macro) = config.function.swift_name_macro {
             if let Some(swift_name) = func.swift_name(config) {
                 // XXX Should this account for `layout`?
-                write!(out, " {}({})", swift_name_macro, swift_name);
+                write!(out, " {swift_name_macro}({swift_name})");
             }
         }
 
@@ -220,7 +220,7 @@ pub trait LanguageBackend: Sized {
     fn write_trailer<W: Write>(&mut self, out: &mut SourceWriter<W>, b: &Bindings) {
         if let Some(ref f) = b.config.trailer {
             out.new_line_if_not_start();
-            write!(out, "{}", f);
+            write!(out, "{f}");
             if !f.ends_with('\n') {
                 out.new_line();
             }

--- a/src/bindgen/rename.rs
+++ b/src/bindgen/rename.rs
@@ -140,7 +140,7 @@ impl FromStr for RenameRule {
 
             s if s.starts_with(PREFIX) => Ok(RenameRule::Prefix(s[PREFIX_LEN..].to_string())),
 
-            _ => Err(format!("Unrecognized RenameRule: '{}'.", s)),
+            _ => Err(format!("Unrecognized RenameRule: '{s}'.")),
         }
     }
 }

--- a/src/bindgen/writer.rs
+++ b/src/bindgen/writer.rs
@@ -196,12 +196,12 @@ impl<'a, F: Write> SourceWriter<'a, F> {
     }
 
     pub fn write(&mut self, text: &'static str) {
-        write!(self, "{}", text);
+        write!(self, "{text}");
     }
 
     pub fn write_raw_block(&mut self, block: &str) {
         self.line_started = true;
-        write!(self, "{}", block);
+        write!(self, "{block}");
     }
 
     pub fn write_fmt(&mut self, fmt: ::std::fmt::Arguments) {
@@ -225,11 +225,11 @@ impl<'a, F: Write> SourceWriter<'a, F> {
             match list_type {
                 ListType::Join(text) => {
                     if i != items.len() - 1 {
-                        write!(self, "{}", text);
+                        write!(self, "{text}");
                     }
                 }
                 ListType::Cap(text) => {
-                    write!(self, "{}", text);
+                    write!(self, "{text}");
                 }
             }
         }
@@ -254,11 +254,11 @@ impl<'a, F: Write> SourceWriter<'a, F> {
             match list_type {
                 ListType::Join(text) => {
                     if i != items.len() - 1 {
-                        write!(self, "{}", text);
+                        write!(self, "{text}");
                     }
                 }
                 ListType::Cap(text) => {
-                    write!(self, "{}", text);
+                    write!(self, "{text}");
                 }
             }
 

--- a/tests/depfile.rs
+++ b/tests/depfile.rs
@@ -18,7 +18,7 @@ fn test_project(project_path: &str) {
     }
     let project_dir = PathBuf::from(project_path);
 
-    let cbindgen_define = format!("-DCBINDGEN_PATH={}", CBINDGEN_PATH);
+    let cbindgen_define = format!("-DCBINDGEN_PATH={CBINDGEN_PATH}");
     cmake_configure
         .arg("-S")
         .arg(project_path)
@@ -30,9 +30,7 @@ fn test_project(project_path: &str) {
     let stderr_str = String::from_utf8(output.stderr).unwrap();
     assert!(
         output.status.success(),
-        "Configuring test project failed: stdout: `{}`, stderr: `{}`",
-        stdout_str,
-        stderr_str
+        "Configuring test project failed: stdout: `{stdout_str}`, stderr: `{stderr_str}`"
     );
     let depfile_path = build_dir.join("depfile.d");
     assert!(
@@ -46,14 +44,12 @@ fn test_project(project_path: &str) {
     let output = cmake_build.output().expect("Failed to execute process");
     assert!(
         output.status.success(),
-        "Building test project failed: {:?}",
-        output
+        "Building test project failed: {output:?}"
     );
     let out_str = String::from_utf8(output.stdout).unwrap();
     assert!(
         out_str.contains("Running cbindgen"),
-        "cbindgen rule did not run. Output: {}",
-        out_str
+        "cbindgen rule did not run. Output: {out_str}"
     );
 
     assert!(
@@ -91,8 +87,7 @@ fn test_project(project_path: &str) {
     let output = cmake_build.output().expect("Failed to execute process");
     assert!(
         output.status.success(),
-        "Building test project failed: {:?}",
-        output
+        "Building test project failed: {output:?}"
     );
     let out_str = String::from_utf8(output.stdout).unwrap();
     assert!(


### PR DESCRIPTION
I updated to 2021 edition so this could be consistently applied in panic
and assert messages as well. There were no changes suggested by
`cargo fix --edition` beforehand, and the MSRV is unchanged.

I also removed `.clippy.toml` because Clippy uses `package.rust-version`
these days, and it was warning that these had different versions.
