### PR TITLE
Check for CMSE ABI's as well

### DIFF
--- a/src/bindgen/parser.rs
+++ b/src/bindgen/parser.rs
@@ -728,7 +728,7 @@ impl Parse {
             items.join("::")
         };
 
-        let is_extern_c = sig.abi.is_omitted() || sig.abi.is_c();
+        let is_extern_c = sig.abi.is_omitted() || sig.abi.is_c() || sig.abi.is_cmse();
         let exported_name = named_symbol.exported_name();
 
         match (is_extern_c, exported_name) {

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -371,24 +371,19 @@ impl_syn_item_helper!(syn::ItemTraitAlias);
 /// Helper function for accessing Abi information
 pub trait SynAbiHelpers {
     fn is_c(&self) -> bool;
+    fn is_cmse(&self) -> bool;
     fn is_omitted(&self) -> bool;
 }
 
 impl SynAbiHelpers for Option<syn::Abi> {
     fn is_c(&self) -> bool {
-        if let Some(ref abi) = *self {
-            if let Some(ref lit_string) = abi.name {
-                return matches!(lit_string.value().as_str(), "C" | "C-unwind");
-            }
-        }
-        false
+        self.as_ref().is_some_and(|abi| abi.is_c())
+    }
+    fn is_cmse(&self) -> bool {
+        self.as_ref().is_some_and(|abi| abi.is_cmse())
     }
     fn is_omitted(&self) -> bool {
-        if let Some(ref abi) = *self {
-            abi.name.is_none()
-        } else {
-            false
-        }
+        self.as_ref().is_some_and(|abi| abi.is_omitted())
     }
 }
 
@@ -396,6 +391,16 @@ impl SynAbiHelpers for syn::Abi {
     fn is_c(&self) -> bool {
         if let Some(ref lit_string) = self.name {
             matches!(lit_string.value().as_str(), "C" | "C-unwind")
+        } else {
+            false
+        }
+    }
+    fn is_cmse(&self) -> bool {
+        if let Some(ref lit_string) = self.name {
+            return matches!(
+                lit_string.value().as_str(),
+                "cmse-nonsecure-entry" | "cmse-nonsecure-call"
+            );
         } else {
             false
         }


### PR DESCRIPTION
Rust has nightly support for Cortex-M Security Extension through the [`cmse-nonsecure-entry`](https://doc.rust-lang.org/beta/unstable-book/language-features/cmse-nonsecure-entry.html) and [`cmse-nonsecure-call`](https://doc.rust-lang.org/beta/unstable-book/language-features/abi-c-cmse-nonsecure-call.html) ABIs. These are compatible with C but cause the compiler to insert extra instructions such as clearing sensitive registers before jumps. 

Therefore it would be convenient if cbindgen was able to generate declarations for functions annotated with these ABIs as well. This PR adds basic support for these ABIs by slightly relaxing the filter.