### PR TITLE
fix: NonNull<()> doesn't lower to `void *`

### DIFF
--- a/tests/expectations-symbols/nonnull_unit.c.sym
+++ b/tests/expectations-symbols/nonnull_unit.c.sym
@@ -1,0 +1,4 @@
+{
+takes_id;
+takes_unit_ptr;
+};

--- a/tests/expectations/nonnull_unit.c
+++ b/tests/expectations/nonnull_unit.c
@@ -1,0 +1,10 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef void *MyId;
+
+void takes_id(MyId id);
+
+void takes_unit_ptr(void *id);

--- a/tests/expectations/nonnull_unit.compat.c
+++ b/tests/expectations/nonnull_unit.compat.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef void *MyId;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void takes_id(MyId id);
+
+void takes_unit_ptr(void *id);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tests/expectations/nonnull_unit.cpp
+++ b/tests/expectations/nonnull_unit.cpp
@@ -1,0 +1,15 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+using MyId = void*;
+
+extern "C" {
+
+void takes_id(MyId id);
+
+void takes_unit_ptr(void *id);
+
+}  // extern "C"

--- a/tests/expectations/nonnull_unit.pyx
+++ b/tests/expectations/nonnull_unit.pyx
@@ -1,0 +1,13 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  ctypedef void *MyId;
+
+  void takes_id(MyId id);
+
+  void takes_unit_ptr(void *id);

--- a/tests/rust/nonnull_unit.rs
+++ b/tests/rust/nonnull_unit.rs
@@ -1,0 +1,16 @@
+use core::ptr::NonNull;
+
+// Reproducer: generic argument is a ZST `()` which evaporates in parsing.
+pub type MyId = NonNull<()>;
+
+#[no_mangle]
+pub extern "C" fn takes_id(id: MyId) {
+    let _ = id;
+}
+
+#[no_mangle]
+pub extern "C" fn takes_unit_ptr(id: *mut ()) {
+    let _ = id;
+}
+
+


### PR DESCRIPTION
Without the fix, you get something stupid like this:

```c
#include <stdarg.h>
#include <stdbool.h>
#include <stdint.h>
#include <stdlib.h>

typedef NonNull MyId;

void takes_id(MyId id);

void takes_unit_ptr(void *id);
```

I'm not sure if there's a smarter fix but I've hit this issue several times. It may need to apply to more types. The only one I can think of that might be a candidate is `Box` but I haven't seen `Box<()>` in the wild myself so I didn't include it.