### PR TITLE
harden cargo invocation: remove reliance on $CARGO

### DIFF
--- a/src/bindgen/cargo/cargo_expand.rs
+++ b/src/bindgen/cargo/cargo_expand.rs
@@ -69,8 +69,7 @@ pub fn expand(
     expand_features: &Option<Vec<String>>,
     profile: Profile,
 ) -> Result<String, Error> {
-    let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
-    let mut cmd = Command::new(cargo);
+    let mut cmd = Command::new("cargo");
 
     let mut _temp_dir = None; // drop guard
     if use_tempdir {

--- a/src/bindgen/cargo/cargo_metadata.rs
+++ b/src/bindgen/cargo/cargo_metadata.rs
@@ -230,8 +230,7 @@ pub fn metadata(
                 None
             };
 
-            let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
-            let mut cmd = Command::new(cargo);
+            let mut cmd = Command::new("cargo");
             cmd.arg("metadata");
             cmd.arg("--all-features");
             cmd.arg("--format-version").arg("1");


### PR DESCRIPTION
Currently cbindgen looks up the `CARGO` environment variable and falls back to `"cargo"` if unset. This means any process that can influence the environment (e.g. by setting `CARGO=/tmp/evil`) could cause cbindgen to run an arbitrary binary with the privileges of the invoking process.

This patch changes the callsites in `cargo_expand.rs` and `cargo_metadata.rs` to invoke `"cargo"` directly instead of honoring `$CARGO`.

The call sites are linked below:
1. `src/bindgen/cargo/cargo_expand.rs:72` : [Link](https://github.com/mozilla/cbindgen/blob/bb131877537bb324f56194938c0f74422f679e65/src/bindgen/cargo/cargo_expand.rs#L72)
2. `src/bindgen/cargo/cargo_metadata.rs:234` : [Link](https://github.com/mozilla/cbindgen/blob/bb131877537bb324f56194938c0f74422f679e65/src/bindgen/cargo/cargo_metadata.rs#L233)

Benefits:
- Principle of least privilege: reduces attack surface in environments where `$CARGO` may be attacker-controlled (e.g. services, CI).
- Behavior is more predictable and consistent across setups.

Potential trade-off:
- Builds that intentionally override `CARGO` to point to a non-default binary will no longer be respected. If that compatibility is important, an alternative would be to validate `$CARGO` rather than ignore it completely.