### PR TITLE
Remove the "display" feature from the toml dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3"
-toml = "0.9"
+toml = { version = "0.9", default-features = false, features = ["parse", "serde", "std"] }
 proc-macro2 = "1.0.60"
 quote = "1"
 heck = "0.5"


### PR DESCRIPTION
Closes #1104.

The "display" feature brings in the "toml_writer" dependency, which we don't need.

I'm not sure why we don't also see it removed from the Cargo.lock, but we can see that it is removed using:

```
cargo tree -i -p toml_writer --target all
```

Before:

```
toml_writer v1.0.2
└── toml v0.9.2
    └── cbindgen v0.29.0 (/foo/cbindgen)
```

After:

```
warning: nothing to print.

To find dependencies that require specific target platforms, try to use option `--target all` first, and then narrow your search scope accordingly.
```