### PR TITLE
Allow must_use if a reason is specified ([must_use = "reason"])

### DIFF
--- a/src/bindgen/ir/annotation.rs
+++ b/src/bindgen/ir/annotation.rs
@@ -113,7 +113,7 @@ impl AnnotationSet {
             })
             .collect();
 
-        let must_use = attrs.has_attr_word("must_use");
+        let must_use = attrs.has_attr_word("must_use") || attrs.has_attr_namevalue("must_use");
         let deprecated = attrs.find_deprecated_note();
         let mut annotations = HashMap::new();
 

--- a/src/bindgen/utilities.rs
+++ b/src/bindgen/utilities.rs
@@ -149,6 +149,19 @@ pub trait SynAttributeHelpers {
         })
     }
 
+    /// Searches for attributes like `#[test = "..."]`.
+    /// Example:
+    /// - `item.has_attr_namevalue("test")` => `#[test = "..."]`
+    fn has_attr_namevalue(&self, name: &str) -> bool {
+        self.attrs().iter().any(|attr| {
+            if let syn::Meta::NameValue(nv) = &attr.meta {
+                nv.path.is_ident(name)
+            } else {
+                false
+            }
+        })
+    }
+
     /// Searches for attributes like `#[unsafe(test)]`.
     /// Example:
     /// - `item.has_unsafe_attr_word("test")` => `#[unsafe(test)]`


### PR DESCRIPTION
Fixes https://github.com/mozilla/cbindgen/issues/1108

Adds a `has_attr_namevalue` that checks `syn::Meta::NameValue` for the attribute (original only checks ` syn::Meta::Path`). 
must_use now checks for either the `has_attr_word` or the new `has_attr_namevalue`.

I could not get the depfile.rs tests running locally (for both master and my own fork) so I am unsure if they pass. 