### PR TITLE
Use C++ fixed-type enumeration syntax under C23 (or higher) as well

### DIFF
--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -760,7 +760,7 @@ impl Enum {
 
         // Emit typedef specifying the tag enum's size if necessary.
         // In C++ or C23 enums can "inherit" from numeric types (`enum E: uint8_t { ... }`),
-        // but in olders versions of C `typedef uint8_t E` is the only way to give a fixed size to `E`.
+        // but in older versions of C `typedef uint8_t E` is the only way to give a fixed size to `E`.
         if let Some(prim) = size {
             if config.cpp_compatible_c() {
                 out.new_line_if_not_start();

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -680,7 +680,7 @@ impl Enum {
                     }
                     write!(out, " {tag_name}");
 
-                    // Write typed enum syntax (valid in C23 or later or C++)
+                    // Emit typed enum syntax (valid in C23 or later or C++)
                     let cond = if config.cpp_compatible_c() {
                         "defined(__cplusplus) || __STDC_VERSION__ >= 202311L"
                     } else {

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -680,15 +680,20 @@ impl Enum {
                     }
                     write!(out, " {tag_name}");
 
-                    if config.cpp_compatible_c() {
-                        out.new_line();
-                        out.write("#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L");
-                        out.new_line();
-                        write!(out, "  : {prim}");
-                        out.new_line();
-                        out.write("#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L");
-                        out.new_line();
-                    }
+                    // Write typed enum syntax (valid in C23 or later or C++)
+                    let cond = if config.cpp_compatible_c() {
+                        "defined(__cplusplus) || __STDC_VERSION__ >= 202311L"
+                    } else {
+                        "__STDC_VERSION__ >= 202311L"
+                    };
+
+                    out.new_line();
+                    write!(out, "#if {cond}");
+                    out.new_line();
+                    write!(out, "  : {prim}");
+                    out.new_line();
+                    write!(out, "#endif // {cond}");
+                    out.new_line();
                 } else {
                     if config.style.generate_typedef() {
                         out.write("typedef ");
@@ -764,17 +769,39 @@ impl Enum {
         if let Some(prim) = size {
             if config.cpp_compatible_c() {
                 out.new_line_if_not_start();
-                out.write("#if !defined(__cplusplus) && __STDC_VERSION__ < 202311L");
+                out.write("#ifndef __cplusplus");
             }
 
             if config.language != Language::Cxx {
+                if config.language == Language::C {
+                    out.new_line();
+                    out.write("#if __STDC_VERSION__ >= 202311L");
+
+                    out.new_line();
+                    write!(
+                        out,
+                        "{} enum {} {};",
+                        config.language.typedef(),
+                        tag_name,
+                        tag_name
+                    );
+
+                    out.new_line();
+                    out.write("#else");
+                }
+
                 out.new_line();
                 write!(out, "{} {} {};", config.language.typedef(), prim, tag_name);
+
+                if config.language == Language::C {
+                    out.new_line();
+                    out.write("#endif // __STDC_VERSION__ >= 202311L");
+                }
             }
 
             if config.cpp_compatible_c() {
                 out.new_line_if_not_start();
-                out.write("#endif // !defined(__cplusplus) && __STDC_VERSION__ < 202311L");
+                out.write("#endif // __cplusplus");
             }
         }
 

--- a/src/bindgen/ir/enumeration.rs
+++ b/src/bindgen/ir/enumeration.rs
@@ -682,11 +682,11 @@ impl Enum {
 
                     if config.cpp_compatible_c() {
                         out.new_line();
-                        out.write("#ifdef __cplusplus");
+                        out.write("#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L");
                         out.new_line();
                         write!(out, "  : {prim}");
                         out.new_line();
-                        out.write("#endif // __cplusplus");
+                        out.write("#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L");
                         out.new_line();
                     }
                 } else {
@@ -759,12 +759,12 @@ impl Enum {
         }
 
         // Emit typedef specifying the tag enum's size if necessary.
-        // In C++ enums can "inherit" from numeric types (`enum E: uint8_t { ... }`),
-        // but in C `typedef uint8_t E` is the only way to give a fixed size to `E`.
+        // In C++ or C23 enums can "inherit" from numeric types (`enum E: uint8_t { ... }`),
+        // but in olders versions of C `typedef uint8_t E` is the only way to give a fixed size to `E`.
         if let Some(prim) = size {
             if config.cpp_compatible_c() {
                 out.new_line_if_not_start();
-                out.write("#ifndef __cplusplus");
+                out.write("#if !defined(__cplusplus) && __STDC_VERSION__ < 202311L");
             }
 
             if config.language != Language::Cxx {
@@ -774,7 +774,7 @@ impl Enum {
 
             if config.cpp_compatible_c() {
                 out.new_line_if_not_start();
-                out.write("#endif // __cplusplus");
+                out.write("#endif // !defined(__cplusplus) && __STDC_VERSION__ < 202311L");
             }
         }
 

--- a/tests/expectations/alias.c
+++ b/tests/expectations/alias.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum Status {
+enum Status
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Ok,
   Err,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Status Status;
+#else
 typedef uint32_t Status;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   int32_t a;

--- a/tests/expectations/alias.compat.c
+++ b/tests/expectations/alias.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum Status
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Ok,
   Err,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Status Status;
+#else
 typedef uint32_t Status;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/alias_both.c
+++ b/tests/expectations/alias_both.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum Status {
+enum Status
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Ok,
   Err,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Status Status;
+#else
 typedef uint32_t Status;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct Dep {
   int32_t a;

--- a/tests/expectations/alias_both.compat.c
+++ b/tests/expectations/alias_both.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum Status
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Ok,
   Err,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Status Status;
+#else
 typedef uint32_t Status;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct Dep {

--- a/tests/expectations/alias_tag.c
+++ b/tests/expectations/alias_tag.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum Status {
+enum Status
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Ok,
   Err,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Status Status;
+#else
 typedef uint32_t Status;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct Dep {
   int32_t a;

--- a/tests/expectations/alias_tag.compat.c
+++ b/tests/expectations/alias_tag.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum Status
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Ok,
   Err,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Status Status;
+#else
 typedef uint32_t Status;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct Dep {

--- a/tests/expectations/annotation.c
+++ b/tests/expectations/annotation.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum C {
+enum C
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   X = 2,
   Y,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   int32_t m0;
@@ -18,12 +26,20 @@ typedef struct {
   float y;
 } B;
 
-enum F_Tag {
+enum F_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
   Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   F_Tag tag;
@@ -40,12 +56,20 @@ typedef union {
   Bar_Body bar;
 } F;
 
-enum H_Tag {
+enum H_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Hello,
   There,
   Everyone,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   uint8_t x;

--- a/tests/expectations/annotation.compat.c
+++ b/tests/expectations/annotation.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum C
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   X = 2,
   Y,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -25,16 +29,20 @@ typedef struct {
 } B;
 
 enum F_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
   Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -53,16 +61,20 @@ typedef union {
 } F;
 
 enum H_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Hello,
   There,
   Everyone,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/annotation_both.c
+++ b/tests/expectations/annotation_both.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum C {
+enum C
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   X = 2,
   Y,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct A {
   int32_t m0;
@@ -18,12 +26,20 @@ typedef struct B {
   float y;
 } B;
 
-enum F_Tag {
+enum F_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
   Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct Bar_Body {
   F_Tag tag;
@@ -40,12 +56,20 @@ typedef union F {
   Bar_Body bar;
 } F;
 
-enum H_Tag {
+enum H_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Hello,
   There,
   Everyone,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct There_Body {
   uint8_t x;

--- a/tests/expectations/annotation_both.compat.c
+++ b/tests/expectations/annotation_both.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum C
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   X = 2,
   Y,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct A {
@@ -25,16 +29,20 @@ typedef struct B {
 } B;
 
 enum F_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
   Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct Bar_Body {
@@ -53,16 +61,20 @@ typedef union F {
 } F;
 
 enum H_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Hello,
   There,
   Everyone,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct There_Body {

--- a/tests/expectations/annotation_tag.c
+++ b/tests/expectations/annotation_tag.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum C {
+enum C
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   X = 2,
   Y,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct A {
   int32_t m0;
@@ -18,12 +26,20 @@ struct B {
   float y;
 };
 
-enum F_Tag {
+enum F_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
   Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct Bar_Body {
   F_Tag tag;
@@ -40,12 +56,20 @@ union F {
   struct Bar_Body bar;
 };
 
-enum H_Tag {
+enum H_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Hello,
   There,
   Everyone,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct There_Body {
   uint8_t x;

--- a/tests/expectations/annotation_tag.compat.c
+++ b/tests/expectations/annotation_tag.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum C
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   X = 2,
   Y,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct A {
@@ -25,16 +29,20 @@ struct B {
 };
 
 enum F_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
   Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct Bar_Body {
@@ -53,16 +61,20 @@ union F {
 };
 
 enum H_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Hello,
   There,
   Everyone,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct There_Body {

--- a/tests/expectations/asserted_cast.c
+++ b/tests/expectations/asserted_cast.c
@@ -9,12 +9,20 @@
 
 typedef struct I I;
 
-enum H_Tag {
+enum H_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   H_Foo,
   H_Bar,
   H_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   uint8_t x;
@@ -31,12 +39,20 @@ typedef struct {
   };
 } H;
 
-enum J_Tag {
+enum J_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   J_Foo,
   J_Bar,
   J_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum J_Tag J_Tag;
+#else
 typedef uint8_t J_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   uint8_t x;
@@ -53,12 +69,20 @@ typedef struct {
   };
 } J;
 
-enum K_Tag {
+enum K_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   K_Foo,
   K_Bar,
   K_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum K_Tag K_Tag;
+#else
 typedef uint8_t K_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   K_Tag tag;

--- a/tests/expectations/asserted_cast.compat.c
+++ b/tests/expectations/asserted_cast.compat.c
@@ -10,16 +10,20 @@
 typedef struct I I;
 
 enum H_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   H_Foo,
   H_Bar,
   H_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -38,16 +42,20 @@ typedef struct {
 } H;
 
 enum J_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   J_Foo,
   J_Bar,
   J_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum J_Tag J_Tag;
+#else
 typedef uint8_t J_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -66,16 +74,20 @@ typedef struct {
 } J;
 
 enum K_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   K_Foo,
   K_Bar,
   K_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum K_Tag K_Tag;
+#else
 typedef uint8_t K_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/asserted_cast_both.c
+++ b/tests/expectations/asserted_cast_both.c
@@ -9,12 +9,20 @@
 
 typedef struct I I;
 
-enum H_Tag {
+enum H_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   H_Foo,
   H_Bar,
   H_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct H_Bar_Body {
   uint8_t x;
@@ -31,12 +39,20 @@ typedef struct H {
   };
 } H;
 
-enum J_Tag {
+enum J_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   J_Foo,
   J_Bar,
   J_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum J_Tag J_Tag;
+#else
 typedef uint8_t J_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct J_Bar_Body {
   uint8_t x;
@@ -53,12 +69,20 @@ typedef struct J {
   };
 } J;
 
-enum K_Tag {
+enum K_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   K_Foo,
   K_Bar,
   K_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum K_Tag K_Tag;
+#else
 typedef uint8_t K_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct K_Bar_Body {
   K_Tag tag;

--- a/tests/expectations/asserted_cast_both.compat.c
+++ b/tests/expectations/asserted_cast_both.compat.c
@@ -10,16 +10,20 @@
 typedef struct I I;
 
 enum H_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   H_Foo,
   H_Bar,
   H_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct H_Bar_Body {
@@ -38,16 +42,20 @@ typedef struct H {
 } H;
 
 enum J_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   J_Foo,
   J_Bar,
   J_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum J_Tag J_Tag;
+#else
 typedef uint8_t J_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct J_Bar_Body {
@@ -66,16 +74,20 @@ typedef struct J {
 } J;
 
 enum K_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   K_Foo,
   K_Bar,
   K_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum K_Tag K_Tag;
+#else
 typedef uint8_t K_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct K_Bar_Body {

--- a/tests/expectations/asserted_cast_tag.c
+++ b/tests/expectations/asserted_cast_tag.c
@@ -9,12 +9,20 @@
 
 struct I;
 
-enum H_Tag {
+enum H_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   H_Foo,
   H_Bar,
   H_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct H_Bar_Body {
   uint8_t x;
@@ -31,12 +39,20 @@ struct H {
   };
 };
 
-enum J_Tag {
+enum J_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   J_Foo,
   J_Bar,
   J_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum J_Tag J_Tag;
+#else
 typedef uint8_t J_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct J_Bar_Body {
   uint8_t x;
@@ -53,12 +69,20 @@ struct J {
   };
 };
 
-enum K_Tag {
+enum K_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   K_Foo,
   K_Bar,
   K_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum K_Tag K_Tag;
+#else
 typedef uint8_t K_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct K_Bar_Body {
   K_Tag tag;

--- a/tests/expectations/asserted_cast_tag.compat.c
+++ b/tests/expectations/asserted_cast_tag.compat.c
@@ -10,16 +10,20 @@
 struct I;
 
 enum H_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   H_Foo,
   H_Bar,
   H_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct H_Bar_Body {
@@ -38,16 +42,20 @@ struct H {
 };
 
 enum J_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   J_Foo,
   J_Bar,
   J_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum J_Tag J_Tag;
+#else
 typedef uint8_t J_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct J_Bar_Body {
@@ -66,16 +74,20 @@ struct J {
 };
 
 enum K_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   K_Foo,
   K_Bar,
   K_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum K_Tag K_Tag;
+#else
 typedef uint8_t K_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct K_Bar_Body {

--- a/tests/expectations/cfg.c
+++ b/tests/expectations/cfg.c
@@ -13,21 +13,37 @@ DEF M_32 = 0
 #include <stdlib.h>
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
-enum FooType {
+enum FooType
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A,
   B,
   C,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum FooType FooType;
+#else
 typedef uint32_t FooType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
-enum BarType {
+enum BarType
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A,
   B,
   C,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum BarType BarType;
+#else
 typedef uint32_t BarType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif
 
 typedef struct {
@@ -59,7 +75,11 @@ typedef struct {
 } FooHandle;
 #endif
 
-enum C_Tag {
+enum C_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   C1,
   C2,
 #if defined(PLATFORM_WIN)
@@ -69,7 +89,11 @@ enum C_Tag {
   C5,
 #endif
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 #if defined(PLATFORM_UNIX)
 typedef struct {

--- a/tests/expectations/cfg.compat.c
+++ b/tests/expectations/cfg.compat.c
@@ -14,31 +14,39 @@ DEF M_32 = 0
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
 enum FooType
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A,
   B,
   C,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum FooType FooType;
+#else
 typedef uint32_t FooType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 #endif
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum BarType
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A,
   B,
   C,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum BarType BarType;
+#else
 typedef uint32_t BarType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 #endif
 
@@ -72,9 +80,9 @@ typedef struct {
 #endif
 
 enum C_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   C1,
   C2,
@@ -86,7 +94,11 @@ enum C_Tag
 #endif
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 #if defined(PLATFORM_UNIX)

--- a/tests/expectations/cfg_both.c
+++ b/tests/expectations/cfg_both.c
@@ -13,21 +13,37 @@ DEF M_32 = 0
 #include <stdlib.h>
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
-enum FooType {
+enum FooType
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A,
   B,
   C,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum FooType FooType;
+#else
 typedef uint32_t FooType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
-enum BarType {
+enum BarType
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A,
   B,
   C,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum BarType BarType;
+#else
 typedef uint32_t BarType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif
 
 typedef struct Flags {
@@ -59,7 +75,11 @@ typedef struct FooHandle {
 } FooHandle;
 #endif
 
-enum C_Tag {
+enum C_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   C1,
   C2,
 #if defined(PLATFORM_WIN)
@@ -69,7 +89,11 @@ enum C_Tag {
   C5,
 #endif
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 #if defined(PLATFORM_UNIX)
 typedef struct C5_Body {

--- a/tests/expectations/cfg_both.compat.c
+++ b/tests/expectations/cfg_both.compat.c
@@ -14,31 +14,39 @@ DEF M_32 = 0
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
 enum FooType
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A,
   B,
   C,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum FooType FooType;
+#else
 typedef uint32_t FooType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 #endif
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum BarType
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A,
   B,
   C,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum BarType BarType;
+#else
 typedef uint32_t BarType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 #endif
 
@@ -72,9 +80,9 @@ typedef struct FooHandle {
 #endif
 
 enum C_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   C1,
   C2,
@@ -86,7 +94,11 @@ enum C_Tag
 #endif
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 #if defined(PLATFORM_UNIX)

--- a/tests/expectations/cfg_tag.c
+++ b/tests/expectations/cfg_tag.c
@@ -13,21 +13,37 @@ DEF M_32 = 0
 #include <stdlib.h>
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
-enum FooType {
+enum FooType
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A,
   B,
   C,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum FooType FooType;
+#else
 typedef uint32_t FooType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
-enum BarType {
+enum BarType
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A,
   B,
   C,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum BarType BarType;
+#else
 typedef uint32_t BarType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif
 
 struct Flags {
@@ -59,7 +75,11 @@ struct FooHandle {
 };
 #endif
 
-enum C_Tag {
+enum C_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   C1,
   C2,
 #if defined(PLATFORM_WIN)
@@ -69,7 +89,11 @@ enum C_Tag {
   C5,
 #endif
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 #if defined(PLATFORM_UNIX)
 struct C5_Body {

--- a/tests/expectations/cfg_tag.compat.c
+++ b/tests/expectations/cfg_tag.compat.c
@@ -14,31 +14,39 @@ DEF M_32 = 0
 
 #if (defined(PLATFORM_UNIX) && defined(X11))
 enum FooType
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A,
   B,
   C,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum FooType FooType;
+#else
 typedef uint32_t FooType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 #endif
 
 #if (defined(PLATFORM_WIN) || defined(M_32))
 enum BarType
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A,
   B,
   C,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum BarType BarType;
+#else
 typedef uint32_t BarType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 #endif
 
@@ -72,9 +80,9 @@ struct FooHandle {
 #endif
 
 enum C_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   C1,
   C2,
@@ -86,7 +94,11 @@ enum C_Tag
 #endif
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 #if defined(PLATFORM_UNIX)

--- a/tests/expectations/decl_name_conflicting.c
+++ b/tests/expectations/decl_name_conflicting.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum BindingType {
+enum BindingType
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Buffer = 0,
   NotBuffer = 1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum BindingType BindingType;
+#else
 typedef uint32_t BindingType;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   BindingType ty;

--- a/tests/expectations/decl_name_conflicting.compat.c
+++ b/tests/expectations/decl_name_conflicting.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum BindingType
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Buffer = 0,
   NotBuffer = 1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum BindingType BindingType;
+#else
 typedef uint32_t BindingType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/decl_name_conflicting_both.c
+++ b/tests/expectations/decl_name_conflicting_both.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum BindingType {
+enum BindingType
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Buffer = 0,
   NotBuffer = 1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum BindingType BindingType;
+#else
 typedef uint32_t BindingType;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct BindGroupLayoutEntry {
   BindingType ty;

--- a/tests/expectations/decl_name_conflicting_both.compat.c
+++ b/tests/expectations/decl_name_conflicting_both.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum BindingType
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Buffer = 0,
   NotBuffer = 1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum BindingType BindingType;
+#else
 typedef uint32_t BindingType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct BindGroupLayoutEntry {

--- a/tests/expectations/decl_name_conflicting_tag.c
+++ b/tests/expectations/decl_name_conflicting_tag.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum BindingType {
+enum BindingType
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Buffer = 0,
   NotBuffer = 1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum BindingType BindingType;
+#else
 typedef uint32_t BindingType;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct BindGroupLayoutEntry {
   BindingType ty;

--- a/tests/expectations/decl_name_conflicting_tag.compat.c
+++ b/tests/expectations/decl_name_conflicting_tag.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum BindingType
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Buffer = 0,
   NotBuffer = 1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum BindingType BindingType;
+#else
 typedef uint32_t BindingType;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct BindGroupLayoutEntry {

--- a/tests/expectations/deprecated.c
+++ b/tests/expectations/deprecated.c
@@ -13,23 +13,47 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum DEPRECATED_ENUM DeprecatedEnum {
+enum DEPRECATED_ENUM DeprecatedEnum
+#if __STDC_VERSION__ >= 202311L
+  : int32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A = 0,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnum DeprecatedEnum;
+#else
 typedef int32_t DeprecatedEnum;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum DEPRECATED_ENUM_WITH_NOTE("This is a note") DeprecatedEnumWithNote {
+enum DEPRECATED_ENUM_WITH_NOTE("This is a note") DeprecatedEnumWithNote
+#if __STDC_VERSION__ >= 202311L
+  : int32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   B = 0,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnumWithNote DeprecatedEnumWithNote;
+#else
 typedef int32_t DeprecatedEnumWithNote;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum EnumWithDeprecatedVariants {
+enum EnumWithDeprecatedVariants
+#if __STDC_VERSION__ >= 202311L
+  : int32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   C = 0,
   D DEPRECATED_ENUM_VARIANT = 1,
   E DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note") = 2,
   F DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note") = 3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedVariants EnumWithDeprecatedVariants;
+#else
 typedef int32_t EnumWithDeprecatedVariants;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct DEPRECATED_STRUCT {
   int32_t a;
@@ -39,12 +63,20 @@ typedef struct DEPRECATED_STRUCT_WITH_NOTE("This is a note") {
   int32_t a;
 } DeprecatedStructWithNote;
 
-enum EnumWithDeprecatedStructVariants_Tag {
+enum EnumWithDeprecatedStructVariants_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar DEPRECATED_ENUM_VARIANT,
   Baz DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note"),
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedStructVariants_Tag EnumWithDeprecatedStructVariants_Tag;
+#else
 typedef uint8_t EnumWithDeprecatedStructVariants_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct DEPRECATED_STRUCT {
   EnumWithDeprecatedStructVariants_Tag tag;

--- a/tests/expectations/deprecated.compat.c
+++ b/tests/expectations/deprecated.compat.c
@@ -14,31 +14,39 @@
 #include <stdlib.h>
 
 enum DEPRECATED_ENUM DeprecatedEnum
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A = 0,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnum DeprecatedEnum;
+#else
 typedef int32_t DeprecatedEnum;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum DEPRECATED_ENUM_WITH_NOTE("This is a note") DeprecatedEnumWithNote
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   B = 0,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnumWithNote DeprecatedEnumWithNote;
+#else
 typedef int32_t DeprecatedEnumWithNote;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum EnumWithDeprecatedVariants
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   C = 0,
   D DEPRECATED_ENUM_VARIANT = 1,
@@ -46,7 +54,11 @@ enum EnumWithDeprecatedVariants
   F DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note") = 3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedVariants EnumWithDeprecatedVariants;
+#else
 typedef int32_t EnumWithDeprecatedVariants;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct DEPRECATED_STRUCT {
@@ -58,16 +70,20 @@ typedef struct DEPRECATED_STRUCT_WITH_NOTE("This is a note") {
 } DeprecatedStructWithNote;
 
 enum EnumWithDeprecatedStructVariants_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar DEPRECATED_ENUM_VARIANT,
   Baz DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note"),
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedStructVariants_Tag EnumWithDeprecatedStructVariants_Tag;
+#else
 typedef uint8_t EnumWithDeprecatedStructVariants_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct DEPRECATED_STRUCT {

--- a/tests/expectations/deprecated_both.c
+++ b/tests/expectations/deprecated_both.c
@@ -13,23 +13,47 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum DEPRECATED_ENUM DeprecatedEnum {
+enum DEPRECATED_ENUM DeprecatedEnum
+#if __STDC_VERSION__ >= 202311L
+  : int32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A = 0,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnum DeprecatedEnum;
+#else
 typedef int32_t DeprecatedEnum;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum DEPRECATED_ENUM_WITH_NOTE("This is a note") DeprecatedEnumWithNote {
+enum DEPRECATED_ENUM_WITH_NOTE("This is a note") DeprecatedEnumWithNote
+#if __STDC_VERSION__ >= 202311L
+  : int32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   B = 0,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnumWithNote DeprecatedEnumWithNote;
+#else
 typedef int32_t DeprecatedEnumWithNote;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum EnumWithDeprecatedVariants {
+enum EnumWithDeprecatedVariants
+#if __STDC_VERSION__ >= 202311L
+  : int32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   C = 0,
   D DEPRECATED_ENUM_VARIANT = 1,
   E DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note") = 2,
   F DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note") = 3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedVariants EnumWithDeprecatedVariants;
+#else
 typedef int32_t EnumWithDeprecatedVariants;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct DEPRECATED_STRUCT DeprecatedStruct {
   int32_t a;
@@ -39,12 +63,20 @@ typedef struct DEPRECATED_STRUCT_WITH_NOTE("This is a note") DeprecatedStructWit
   int32_t a;
 } DeprecatedStructWithNote;
 
-enum EnumWithDeprecatedStructVariants_Tag {
+enum EnumWithDeprecatedStructVariants_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar DEPRECATED_ENUM_VARIANT,
   Baz DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note"),
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedStructVariants_Tag EnumWithDeprecatedStructVariants_Tag;
+#else
 typedef uint8_t EnumWithDeprecatedStructVariants_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct DEPRECATED_STRUCT Bar_Body {
   EnumWithDeprecatedStructVariants_Tag tag;

--- a/tests/expectations/deprecated_both.compat.c
+++ b/tests/expectations/deprecated_both.compat.c
@@ -14,31 +14,39 @@
 #include <stdlib.h>
 
 enum DEPRECATED_ENUM DeprecatedEnum
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A = 0,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnum DeprecatedEnum;
+#else
 typedef int32_t DeprecatedEnum;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum DEPRECATED_ENUM_WITH_NOTE("This is a note") DeprecatedEnumWithNote
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   B = 0,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnumWithNote DeprecatedEnumWithNote;
+#else
 typedef int32_t DeprecatedEnumWithNote;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum EnumWithDeprecatedVariants
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   C = 0,
   D DEPRECATED_ENUM_VARIANT = 1,
@@ -46,7 +54,11 @@ enum EnumWithDeprecatedVariants
   F DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note") = 3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedVariants EnumWithDeprecatedVariants;
+#else
 typedef int32_t EnumWithDeprecatedVariants;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct DEPRECATED_STRUCT DeprecatedStruct {
@@ -58,16 +70,20 @@ typedef struct DEPRECATED_STRUCT_WITH_NOTE("This is a note") DeprecatedStructWit
 } DeprecatedStructWithNote;
 
 enum EnumWithDeprecatedStructVariants_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar DEPRECATED_ENUM_VARIANT,
   Baz DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note"),
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedStructVariants_Tag EnumWithDeprecatedStructVariants_Tag;
+#else
 typedef uint8_t EnumWithDeprecatedStructVariants_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct DEPRECATED_STRUCT Bar_Body {

--- a/tests/expectations/deprecated_tag.c
+++ b/tests/expectations/deprecated_tag.c
@@ -13,23 +13,47 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum DEPRECATED_ENUM DeprecatedEnum {
+enum DEPRECATED_ENUM DeprecatedEnum
+#if __STDC_VERSION__ >= 202311L
+  : int32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A = 0,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnum DeprecatedEnum;
+#else
 typedef int32_t DeprecatedEnum;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum DEPRECATED_ENUM_WITH_NOTE("This is a note") DeprecatedEnumWithNote {
+enum DEPRECATED_ENUM_WITH_NOTE("This is a note") DeprecatedEnumWithNote
+#if __STDC_VERSION__ >= 202311L
+  : int32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   B = 0,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnumWithNote DeprecatedEnumWithNote;
+#else
 typedef int32_t DeprecatedEnumWithNote;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum EnumWithDeprecatedVariants {
+enum EnumWithDeprecatedVariants
+#if __STDC_VERSION__ >= 202311L
+  : int32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   C = 0,
   D DEPRECATED_ENUM_VARIANT = 1,
   E DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note") = 2,
   F DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note") = 3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedVariants EnumWithDeprecatedVariants;
+#else
 typedef int32_t EnumWithDeprecatedVariants;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct DEPRECATED_STRUCT DeprecatedStruct {
   int32_t a;
@@ -39,12 +63,20 @@ struct DEPRECATED_STRUCT_WITH_NOTE("This is a note") DeprecatedStructWithNote {
   int32_t a;
 };
 
-enum EnumWithDeprecatedStructVariants_Tag {
+enum EnumWithDeprecatedStructVariants_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar DEPRECATED_ENUM_VARIANT,
   Baz DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note"),
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedStructVariants_Tag EnumWithDeprecatedStructVariants_Tag;
+#else
 typedef uint8_t EnumWithDeprecatedStructVariants_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct DEPRECATED_STRUCT Bar_Body {
   EnumWithDeprecatedStructVariants_Tag tag;

--- a/tests/expectations/deprecated_tag.compat.c
+++ b/tests/expectations/deprecated_tag.compat.c
@@ -14,31 +14,39 @@
 #include <stdlib.h>
 
 enum DEPRECATED_ENUM DeprecatedEnum
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A = 0,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnum DeprecatedEnum;
+#else
 typedef int32_t DeprecatedEnum;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum DEPRECATED_ENUM_WITH_NOTE("This is a note") DeprecatedEnumWithNote
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   B = 0,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum DeprecatedEnumWithNote DeprecatedEnumWithNote;
+#else
 typedef int32_t DeprecatedEnumWithNote;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum EnumWithDeprecatedVariants
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   C = 0,
   D DEPRECATED_ENUM_VARIANT = 1,
@@ -46,7 +54,11 @@ enum EnumWithDeprecatedVariants
   F DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note") = 3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedVariants EnumWithDeprecatedVariants;
+#else
 typedef int32_t EnumWithDeprecatedVariants;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct DEPRECATED_STRUCT DeprecatedStruct {
@@ -58,16 +70,20 @@ struct DEPRECATED_STRUCT_WITH_NOTE("This is a note") DeprecatedStructWithNote {
 };
 
 enum EnumWithDeprecatedStructVariants_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar DEPRECATED_ENUM_VARIANT,
   Baz DEPRECATED_ENUM_VARIANT_WITH_NOTE("This is a note"),
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum EnumWithDeprecatedStructVariants_Tag EnumWithDeprecatedStructVariants_Tag;
+#else
 typedef uint8_t EnumWithDeprecatedStructVariants_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct DEPRECATED_STRUCT Bar_Body {

--- a/tests/expectations/derive_eq.c
+++ b/tests/expectations/derive_eq.c
@@ -8,13 +8,21 @@ typedef struct {
   int32_t b;
 } Foo;
 
-enum Bar_Tag {
+enum Bar_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Baz,
   Bazz,
   FooNamed,
   FooParen,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   Bar_Tag tag;

--- a/tests/expectations/derive_eq.compat.c
+++ b/tests/expectations/derive_eq.compat.c
@@ -9,9 +9,9 @@ typedef struct {
 } Foo;
 
 enum Bar_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Baz,
   Bazz,
@@ -19,7 +19,11 @@ enum Bar_Tag
   FooParen,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/derive_eq_both.c
+++ b/tests/expectations/derive_eq_both.c
@@ -8,13 +8,21 @@ typedef struct Foo {
   int32_t b;
 } Foo;
 
-enum Bar_Tag {
+enum Bar_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Baz,
   Bazz,
   FooNamed,
   FooParen,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct Bazz_Body {
   Bar_Tag tag;

--- a/tests/expectations/derive_eq_both.compat.c
+++ b/tests/expectations/derive_eq_both.compat.c
@@ -9,9 +9,9 @@ typedef struct Foo {
 } Foo;
 
 enum Bar_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Baz,
   Bazz,
@@ -19,7 +19,11 @@ enum Bar_Tag
   FooParen,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct Bazz_Body {

--- a/tests/expectations/derive_eq_tag.c
+++ b/tests/expectations/derive_eq_tag.c
@@ -8,13 +8,21 @@ struct Foo {
   int32_t b;
 };
 
-enum Bar_Tag {
+enum Bar_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Baz,
   Bazz,
   FooNamed,
   FooParen,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct Bazz_Body {
   Bar_Tag tag;

--- a/tests/expectations/derive_eq_tag.compat.c
+++ b/tests/expectations/derive_eq_tag.compat.c
@@ -9,9 +9,9 @@ struct Foo {
 };
 
 enum Bar_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Baz,
   Bazz,
@@ -19,7 +19,11 @@ enum Bar_Tag
   FooParen,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct Bazz_Body {

--- a/tests/expectations/derive_ostream.c
+++ b/tests/expectations/derive_ostream.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum C {
+enum C
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   X = 2,
   Y,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   int32_t _0;
@@ -24,12 +32,20 @@ typedef struct {
   B Things;
 } D;
 
-enum F_Tag {
+enum F_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
   Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   F_Tag tag;
@@ -46,12 +62,20 @@ typedef union {
   Bar_Body bar;
 } F;
 
-enum H_Tag {
+enum H_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Hello,
   There,
   Everyone,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   uint8_t x;
@@ -68,11 +92,19 @@ typedef struct {
   };
 } H;
 
-enum I_Tag {
+enum I_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   ThereAgain,
   SomethingElse,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum I_Tag I_Tag;
+#else
 typedef uint8_t I_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   uint8_t x;

--- a/tests/expectations/derive_ostream.compat.c
+++ b/tests/expectations/derive_ostream.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum C
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   X = 2,
   Y,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -31,16 +35,20 @@ typedef struct {
 } D;
 
 enum F_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
   Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -59,16 +67,20 @@ typedef union {
 } F;
 
 enum H_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Hello,
   There,
   Everyone,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -87,15 +99,19 @@ typedef struct {
 } H;
 
 enum I_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   ThereAgain,
   SomethingElse,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum I_Tag I_Tag;
+#else
 typedef uint8_t I_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/derive_ostream_both.c
+++ b/tests/expectations/derive_ostream_both.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum C {
+enum C
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   X = 2,
   Y,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct A {
   int32_t _0;
@@ -24,12 +32,20 @@ typedef struct D {
   struct B Things;
 } D;
 
-enum F_Tag {
+enum F_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
   Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct Bar_Body {
   F_Tag tag;
@@ -46,12 +62,20 @@ typedef union F {
   Bar_Body bar;
 } F;
 
-enum H_Tag {
+enum H_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Hello,
   There,
   Everyone,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct There_Body {
   uint8_t x;
@@ -68,11 +92,19 @@ typedef struct H {
   };
 } H;
 
-enum I_Tag {
+enum I_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   ThereAgain,
   SomethingElse,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum I_Tag I_Tag;
+#else
 typedef uint8_t I_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct ThereAgain_Body {
   uint8_t x;

--- a/tests/expectations/derive_ostream_both.compat.c
+++ b/tests/expectations/derive_ostream_both.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum C
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   X = 2,
   Y,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct A {
@@ -31,16 +35,20 @@ typedef struct D {
 } D;
 
 enum F_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
   Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct Bar_Body {
@@ -59,16 +67,20 @@ typedef union F {
 } F;
 
 enum H_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Hello,
   There,
   Everyone,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct There_Body {
@@ -87,15 +99,19 @@ typedef struct H {
 } H;
 
 enum I_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   ThereAgain,
   SomethingElse,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum I_Tag I_Tag;
+#else
 typedef uint8_t I_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct ThereAgain_Body {

--- a/tests/expectations/derive_ostream_tag.c
+++ b/tests/expectations/derive_ostream_tag.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum C {
+enum C
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   X = 2,
   Y,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct A {
   int32_t _0;
@@ -24,12 +32,20 @@ struct D {
   struct B Things;
 };
 
-enum F_Tag {
+enum F_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
   Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct Bar_Body {
   F_Tag tag;
@@ -46,12 +62,20 @@ union F {
   struct Bar_Body bar;
 };
 
-enum H_Tag {
+enum H_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Hello,
   There,
   Everyone,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct There_Body {
   uint8_t x;
@@ -68,11 +92,19 @@ struct H {
   };
 };
 
-enum I_Tag {
+enum I_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   ThereAgain,
   SomethingElse,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum I_Tag I_Tag;
+#else
 typedef uint8_t I_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct ThereAgain_Body {
   uint8_t x;

--- a/tests/expectations/derive_ostream_tag.compat.c
+++ b/tests/expectations/derive_ostream_tag.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum C
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   X = 2,
   Y,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint32_t C;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct A {
@@ -31,16 +35,20 @@ struct D {
 };
 
 enum F_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
   Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct Bar_Body {
@@ -59,16 +67,20 @@ union F {
 };
 
 enum H_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Hello,
   There,
   Everyone,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum H_Tag H_Tag;
+#else
 typedef uint8_t H_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct There_Body {
@@ -87,15 +99,19 @@ struct H {
 };
 
 enum I_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   ThereAgain,
   SomethingElse,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum I_Tag I_Tag;
+#else
 typedef uint8_t I_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct ThereAgain_Body {

--- a/tests/expectations/destructor_and_copy_ctor.c
+++ b/tests/expectations/destructor_and_copy_ctor.c
@@ -7,11 +7,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum FillRule {
+enum FillRule
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A,
   B,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum FillRule FillRule;
+#else
 typedef uint8_t FillRule;
+#endif // __STDC_VERSION__ >= 202311L
 
 /**
  * This will have a destructor manually implemented via variant_body, and
@@ -36,7 +44,11 @@ typedef struct {
   int32_t *ptr;
 } OwnedSlice_i32;
 
-enum Foo_u32_Tag {
+enum Foo_u32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar_u32,
   Polygon1_u32,
   Slice1_u32,
@@ -44,7 +56,11 @@ enum Foo_u32_Tag {
   Slice3_u32,
   Slice4_u32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Foo_u32_Tag Foo_u32_Tag;
+#else
 typedef uint8_t Foo_u32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   FillRule fill;
@@ -78,7 +94,11 @@ typedef struct {
   OwnedSlice_i32 coordinates;
 } Polygon_i32;
 
-enum Baz_i32_Tag {
+enum Baz_i32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar2_i32,
   Polygon21_i32,
   Slice21_i32,
@@ -86,7 +106,11 @@ enum Baz_i32_Tag {
   Slice23_i32,
   Slice24_i32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Baz_i32_Tag Baz_i32_Tag;
+#else
 typedef uint8_t Baz_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   Baz_i32_Tag tag;
@@ -118,12 +142,20 @@ typedef union {
   Slice24_Body_i32 slice24;
 } Baz_i32;
 
-enum Taz_Tag {
+enum Taz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar3,
   Taz1,
   Taz3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Taz_Tag Taz_Tag;
+#else
 typedef uint8_t Taz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union {
   Taz_Tag tag;
@@ -137,11 +169,19 @@ typedef union {
   };
 } Taz;
 
-enum Tazz_Tag {
+enum Tazz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar4,
   Taz2,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazz_Tag Tazz_Tag;
+#else
 typedef uint8_t Tazz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union {
   Tazz_Tag tag;
@@ -151,11 +191,19 @@ typedef union {
   };
 } Tazz;
 
-enum Tazzz_Tag {
+enum Tazzz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar5,
   Taz5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzz_Tag Tazzz_Tag;
+#else
 typedef uint8_t Tazzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union {
   Tazzz_Tag tag;
@@ -165,11 +213,19 @@ typedef union {
   };
 } Tazzz;
 
-enum Tazzzz_Tag {
+enum Tazzzz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Taz6,
   Taz7,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzzz_Tag Tazzzz_Tag;
+#else
 typedef uint8_t Tazzzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union {
   Tazzzz_Tag tag;
@@ -183,11 +239,19 @@ typedef union {
   };
 } Tazzzz;
 
-enum Qux_Tag {
+enum Qux_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Qux1,
   Qux2,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Qux_Tag Qux_Tag;
+#else
 typedef uint8_t Qux_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union {
   Qux_Tag tag;

--- a/tests/expectations/destructor_and_copy_ctor.compat.c
+++ b/tests/expectations/destructor_and_copy_ctor.compat.c
@@ -8,15 +8,19 @@
 #include <stdlib.h>
 
 enum FillRule
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A,
   B,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum FillRule FillRule;
+#else
 typedef uint8_t FillRule;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 /**
@@ -43,9 +47,9 @@ typedef struct {
 } OwnedSlice_i32;
 
 enum Foo_u32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar_u32,
   Polygon1_u32,
@@ -55,7 +59,11 @@ enum Foo_u32_Tag
   Slice4_u32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Foo_u32_Tag Foo_u32_Tag;
+#else
 typedef uint8_t Foo_u32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -91,9 +99,9 @@ typedef struct {
 } Polygon_i32;
 
 enum Baz_i32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar2_i32,
   Polygon21_i32,
@@ -103,7 +111,11 @@ enum Baz_i32_Tag
   Slice24_i32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Baz_i32_Tag Baz_i32_Tag;
+#else
 typedef uint8_t Baz_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -137,16 +149,20 @@ typedef union {
 } Baz_i32;
 
 enum Taz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar3,
   Taz1,
   Taz3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Taz_Tag Taz_Tag;
+#else
 typedef uint8_t Taz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union {
@@ -162,15 +178,19 @@ typedef union {
 } Taz;
 
 enum Tazz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar4,
   Taz2,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazz_Tag Tazz_Tag;
+#else
 typedef uint8_t Tazz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union {
@@ -182,15 +202,19 @@ typedef union {
 } Tazz;
 
 enum Tazzz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar5,
   Taz5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzz_Tag Tazzz_Tag;
+#else
 typedef uint8_t Tazzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union {
@@ -202,15 +226,19 @@ typedef union {
 } Tazzz;
 
 enum Tazzzz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Taz6,
   Taz7,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzzz_Tag Tazzzz_Tag;
+#else
 typedef uint8_t Tazzzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union {
@@ -226,15 +254,19 @@ typedef union {
 } Tazzzz;
 
 enum Qux_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Qux1,
   Qux2,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Qux_Tag Qux_Tag;
+#else
 typedef uint8_t Qux_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union {

--- a/tests/expectations/destructor_and_copy_ctor_both.c
+++ b/tests/expectations/destructor_and_copy_ctor_both.c
@@ -7,11 +7,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum FillRule {
+enum FillRule
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A,
   B,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum FillRule FillRule;
+#else
 typedef uint8_t FillRule;
+#endif // __STDC_VERSION__ >= 202311L
 
 /**
  * This will have a destructor manually implemented via variant_body, and
@@ -36,7 +44,11 @@ typedef struct OwnedSlice_i32 {
   int32_t *ptr;
 } OwnedSlice_i32;
 
-enum Foo_u32_Tag {
+enum Foo_u32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar_u32,
   Polygon1_u32,
   Slice1_u32,
@@ -44,7 +56,11 @@ enum Foo_u32_Tag {
   Slice3_u32,
   Slice4_u32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Foo_u32_Tag Foo_u32_Tag;
+#else
 typedef uint8_t Foo_u32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct Slice3_Body_u32 {
   FillRule fill;
@@ -78,7 +94,11 @@ typedef struct Polygon_i32 {
   struct OwnedSlice_i32 coordinates;
 } Polygon_i32;
 
-enum Baz_i32_Tag {
+enum Baz_i32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar2_i32,
   Polygon21_i32,
   Slice21_i32,
@@ -86,7 +106,11 @@ enum Baz_i32_Tag {
   Slice23_i32,
   Slice24_i32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Baz_i32_Tag Baz_i32_Tag;
+#else
 typedef uint8_t Baz_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct Slice23_Body_i32 {
   Baz_i32_Tag tag;
@@ -118,12 +142,20 @@ typedef union Baz_i32 {
   Slice24_Body_i32 slice24;
 } Baz_i32;
 
-enum Taz_Tag {
+enum Taz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar3,
   Taz1,
   Taz3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Taz_Tag Taz_Tag;
+#else
 typedef uint8_t Taz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union Taz {
   Taz_Tag tag;
@@ -137,11 +169,19 @@ typedef union Taz {
   };
 } Taz;
 
-enum Tazz_Tag {
+enum Tazz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar4,
   Taz2,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazz_Tag Tazz_Tag;
+#else
 typedef uint8_t Tazz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union Tazz {
   Tazz_Tag tag;
@@ -151,11 +191,19 @@ typedef union Tazz {
   };
 } Tazz;
 
-enum Tazzz_Tag {
+enum Tazzz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar5,
   Taz5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzz_Tag Tazzz_Tag;
+#else
 typedef uint8_t Tazzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union Tazzz {
   Tazzz_Tag tag;
@@ -165,11 +213,19 @@ typedef union Tazzz {
   };
 } Tazzz;
 
-enum Tazzzz_Tag {
+enum Tazzzz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Taz6,
   Taz7,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzzz_Tag Tazzzz_Tag;
+#else
 typedef uint8_t Tazzzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union Tazzzz {
   Tazzzz_Tag tag;
@@ -183,11 +239,19 @@ typedef union Tazzzz {
   };
 } Tazzzz;
 
-enum Qux_Tag {
+enum Qux_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Qux1,
   Qux2,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Qux_Tag Qux_Tag;
+#else
 typedef uint8_t Qux_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union Qux {
   Qux_Tag tag;

--- a/tests/expectations/destructor_and_copy_ctor_both.compat.c
+++ b/tests/expectations/destructor_and_copy_ctor_both.compat.c
@@ -8,15 +8,19 @@
 #include <stdlib.h>
 
 enum FillRule
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A,
   B,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum FillRule FillRule;
+#else
 typedef uint8_t FillRule;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 /**
@@ -43,9 +47,9 @@ typedef struct OwnedSlice_i32 {
 } OwnedSlice_i32;
 
 enum Foo_u32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar_u32,
   Polygon1_u32,
@@ -55,7 +59,11 @@ enum Foo_u32_Tag
   Slice4_u32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Foo_u32_Tag Foo_u32_Tag;
+#else
 typedef uint8_t Foo_u32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct Slice3_Body_u32 {
@@ -91,9 +99,9 @@ typedef struct Polygon_i32 {
 } Polygon_i32;
 
 enum Baz_i32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar2_i32,
   Polygon21_i32,
@@ -103,7 +111,11 @@ enum Baz_i32_Tag
   Slice24_i32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Baz_i32_Tag Baz_i32_Tag;
+#else
 typedef uint8_t Baz_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct Slice23_Body_i32 {
@@ -137,16 +149,20 @@ typedef union Baz_i32 {
 } Baz_i32;
 
 enum Taz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar3,
   Taz1,
   Taz3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Taz_Tag Taz_Tag;
+#else
 typedef uint8_t Taz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union Taz {
@@ -162,15 +178,19 @@ typedef union Taz {
 } Taz;
 
 enum Tazz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar4,
   Taz2,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazz_Tag Tazz_Tag;
+#else
 typedef uint8_t Tazz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union Tazz {
@@ -182,15 +202,19 @@ typedef union Tazz {
 } Tazz;
 
 enum Tazzz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar5,
   Taz5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzz_Tag Tazzz_Tag;
+#else
 typedef uint8_t Tazzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union Tazzz {
@@ -202,15 +226,19 @@ typedef union Tazzz {
 } Tazzz;
 
 enum Tazzzz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Taz6,
   Taz7,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzzz_Tag Tazzzz_Tag;
+#else
 typedef uint8_t Tazzzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union Tazzzz {
@@ -226,15 +254,19 @@ typedef union Tazzzz {
 } Tazzzz;
 
 enum Qux_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Qux1,
   Qux2,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Qux_Tag Qux_Tag;
+#else
 typedef uint8_t Qux_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union Qux {

--- a/tests/expectations/destructor_and_copy_ctor_tag.c
+++ b/tests/expectations/destructor_and_copy_ctor_tag.c
@@ -7,11 +7,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum FillRule {
+enum FillRule
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A,
   B,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum FillRule FillRule;
+#else
 typedef uint8_t FillRule;
+#endif // __STDC_VERSION__ >= 202311L
 
 /**
  * This will have a destructor manually implemented via variant_body, and
@@ -36,7 +44,11 @@ struct OwnedSlice_i32 {
   int32_t *ptr;
 };
 
-enum Foo_u32_Tag {
+enum Foo_u32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar_u32,
   Polygon1_u32,
   Slice1_u32,
@@ -44,7 +56,11 @@ enum Foo_u32_Tag {
   Slice3_u32,
   Slice4_u32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Foo_u32_Tag Foo_u32_Tag;
+#else
 typedef uint8_t Foo_u32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct Slice3_Body_u32 {
   FillRule fill;
@@ -78,7 +94,11 @@ struct Polygon_i32 {
   struct OwnedSlice_i32 coordinates;
 };
 
-enum Baz_i32_Tag {
+enum Baz_i32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar2_i32,
   Polygon21_i32,
   Slice21_i32,
@@ -86,7 +106,11 @@ enum Baz_i32_Tag {
   Slice23_i32,
   Slice24_i32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Baz_i32_Tag Baz_i32_Tag;
+#else
 typedef uint8_t Baz_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct Slice23_Body_i32 {
   Baz_i32_Tag tag;
@@ -118,12 +142,20 @@ union Baz_i32 {
   struct Slice24_Body_i32 slice24;
 };
 
-enum Taz_Tag {
+enum Taz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar3,
   Taz1,
   Taz3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Taz_Tag Taz_Tag;
+#else
 typedef uint8_t Taz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 union Taz {
   Taz_Tag tag;
@@ -137,11 +169,19 @@ union Taz {
   };
 };
 
-enum Tazz_Tag {
+enum Tazz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar4,
   Taz2,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazz_Tag Tazz_Tag;
+#else
 typedef uint8_t Tazz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 union Tazz {
   Tazz_Tag tag;
@@ -151,11 +191,19 @@ union Tazz {
   };
 };
 
-enum Tazzz_Tag {
+enum Tazzz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Bar5,
   Taz5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzz_Tag Tazzz_Tag;
+#else
 typedef uint8_t Tazzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 union Tazzz {
   Tazzz_Tag tag;
@@ -165,11 +213,19 @@ union Tazzz {
   };
 };
 
-enum Tazzzz_Tag {
+enum Tazzzz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Taz6,
   Taz7,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzzz_Tag Tazzzz_Tag;
+#else
 typedef uint8_t Tazzzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 union Tazzzz {
   Tazzzz_Tag tag;
@@ -183,11 +239,19 @@ union Tazzzz {
   };
 };
 
-enum Qux_Tag {
+enum Qux_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Qux1,
   Qux2,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Qux_Tag Qux_Tag;
+#else
 typedef uint8_t Qux_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 union Qux {
   Qux_Tag tag;

--- a/tests/expectations/destructor_and_copy_ctor_tag.compat.c
+++ b/tests/expectations/destructor_and_copy_ctor_tag.compat.c
@@ -8,15 +8,19 @@
 #include <stdlib.h>
 
 enum FillRule
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A,
   B,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum FillRule FillRule;
+#else
 typedef uint8_t FillRule;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 /**
@@ -43,9 +47,9 @@ struct OwnedSlice_i32 {
 };
 
 enum Foo_u32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar_u32,
   Polygon1_u32,
@@ -55,7 +59,11 @@ enum Foo_u32_Tag
   Slice4_u32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Foo_u32_Tag Foo_u32_Tag;
+#else
 typedef uint8_t Foo_u32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct Slice3_Body_u32 {
@@ -91,9 +99,9 @@ struct Polygon_i32 {
 };
 
 enum Baz_i32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar2_i32,
   Polygon21_i32,
@@ -103,7 +111,11 @@ enum Baz_i32_Tag
   Slice24_i32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Baz_i32_Tag Baz_i32_Tag;
+#else
 typedef uint8_t Baz_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct Slice23_Body_i32 {
@@ -137,16 +149,20 @@ union Baz_i32 {
 };
 
 enum Taz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar3,
   Taz1,
   Taz3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Taz_Tag Taz_Tag;
+#else
 typedef uint8_t Taz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 union Taz {
@@ -162,15 +178,19 @@ union Taz {
 };
 
 enum Tazz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar4,
   Taz2,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazz_Tag Tazz_Tag;
+#else
 typedef uint8_t Tazz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 union Tazz {
@@ -182,15 +202,19 @@ union Tazz {
 };
 
 enum Tazzz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Bar5,
   Taz5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzz_Tag Tazzz_Tag;
+#else
 typedef uint8_t Tazzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 union Tazzz {
@@ -202,15 +226,19 @@ union Tazzz {
 };
 
 enum Tazzzz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Taz6,
   Taz7,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Tazzzz_Tag Tazzzz_Tag;
+#else
 typedef uint8_t Tazzzz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 union Tazzzz {
@@ -226,15 +254,19 @@ union Tazzzz {
 };
 
 enum Qux_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Qux1,
   Qux2,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Qux_Tag Qux_Tag;
+#else
 typedef uint8_t Qux_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 union Qux {

--- a/tests/expectations/display_list.c
+++ b/tests/expectations/display_list.c
@@ -17,12 +17,20 @@ typedef struct {
   uint8_t a;
 } Color;
 
-enum DisplayItem_Tag {
+enum DisplayItem_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Fill,
   Image,
   ClearScreen,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum DisplayItem_Tag DisplayItem_Tag;
+#else
 typedef uint8_t DisplayItem_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   DisplayItem_Tag tag;

--- a/tests/expectations/display_list.compat.c
+++ b/tests/expectations/display_list.compat.c
@@ -18,16 +18,20 @@ typedef struct {
 } Color;
 
 enum DisplayItem_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Fill,
   Image,
   ClearScreen,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum DisplayItem_Tag DisplayItem_Tag;
+#else
 typedef uint8_t DisplayItem_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/display_list_both.c
+++ b/tests/expectations/display_list_both.c
@@ -17,12 +17,20 @@ typedef struct Color {
   uint8_t a;
 } Color;
 
-enum DisplayItem_Tag {
+enum DisplayItem_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Fill,
   Image,
   ClearScreen,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum DisplayItem_Tag DisplayItem_Tag;
+#else
 typedef uint8_t DisplayItem_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct Fill_Body {
   DisplayItem_Tag tag;

--- a/tests/expectations/display_list_both.compat.c
+++ b/tests/expectations/display_list_both.compat.c
@@ -18,16 +18,20 @@ typedef struct Color {
 } Color;
 
 enum DisplayItem_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Fill,
   Image,
   ClearScreen,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum DisplayItem_Tag DisplayItem_Tag;
+#else
 typedef uint8_t DisplayItem_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct Fill_Body {

--- a/tests/expectations/display_list_tag.c
+++ b/tests/expectations/display_list_tag.c
@@ -17,12 +17,20 @@ struct Color {
   uint8_t a;
 };
 
-enum DisplayItem_Tag {
+enum DisplayItem_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Fill,
   Image,
   ClearScreen,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum DisplayItem_Tag DisplayItem_Tag;
+#else
 typedef uint8_t DisplayItem_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct Fill_Body {
   DisplayItem_Tag tag;

--- a/tests/expectations/display_list_tag.compat.c
+++ b/tests/expectations/display_list_tag.compat.c
@@ -18,16 +18,20 @@ struct Color {
 };
 
 enum DisplayItem_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Fill,
   Image,
   ClearScreen,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum DisplayItem_Tag DisplayItem_Tag;
+#else
 typedef uint8_t DisplayItem_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct Fill_Body {

--- a/tests/expectations/enum.c
+++ b/tests/expectations/enum.c
@@ -17,53 +17,101 @@ using Box = T*;
 #include <stdint.h>
 #include <stdlib.h>
 
-enum A {
+enum A
+#if __STDC_VERSION__ >= 202311L
+  : uint64_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   a1 = 0,
   a2 = 2,
   a3,
   a4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint64_t A;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum B {
+enum B
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   b1 = 0,
   b2 = 2,
   b3,
   b4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint32_t B;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum C {
+enum C
+#if __STDC_VERSION__ >= 202311L
+  : uint16_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   c1 = 0,
   c2 = 2,
   c3,
   c4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint16_t C;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum D {
+enum D
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   d1 = 0,
   d2 = 2,
   d3,
   d4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum D D;
+#else
 typedef uint8_t D;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum E {
+enum E
+#if __STDC_VERSION__ >= 202311L
+  : uintptr_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   e1 = 0,
   e2 = 2,
   e3,
   e4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum E E;
+#else
 typedef uintptr_t E;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum F {
+enum F
+#if __STDC_VERSION__ >= 202311L
+  : intptr_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   f1 = 0,
   f2 = 2,
   f3,
   f4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F F;
+#else
 typedef intptr_t F;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef enum {
   l1,
@@ -72,12 +120,20 @@ typedef enum {
   l4,
 } L;
 
-enum M {
+enum M
+#if __STDC_VERSION__ >= 202311L
+  : int8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   m1 = -1,
   m2 = 0,
   m3 = 1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum M M;
+#else
 typedef int8_t M;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef enum {
   n1,
@@ -86,13 +142,21 @@ typedef enum {
   n4,
 } N;
 
-enum O {
+enum O
+#if __STDC_VERSION__ >= 202311L
+  : int8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   o1,
   o2,
   o3,
   o4,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum O O;
+#else
 typedef int8_t O;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct J J;
 
@@ -100,12 +164,20 @@ typedef struct K K;
 
 typedef struct Opaque Opaque;
 
-enum G_Tag {
+enum G_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
   Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum G_Tag G_Tag;
+#else
 typedef uint8_t G_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   G_Tag tag;
@@ -143,12 +215,20 @@ typedef struct {
   };
 } H;
 
-enum ExI_Tag {
+enum ExI_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   ExI_Foo,
   ExI_Bar,
   ExI_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum ExI_Tag ExI_Tag;
+#else
 typedef uint8_t ExI_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   uint8_t x;
@@ -165,11 +245,19 @@ typedef struct {
   };
 } ExI;
 
-enum P_Tag {
+enum P_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   P0,
   P1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum P_Tag P_Tag;
+#else
 typedef uint8_t P_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   uint8_t _0;

--- a/tests/expectations/enum.compat.c
+++ b/tests/expectations/enum.compat.c
@@ -18,9 +18,9 @@ using Box = T*;
 #include <stdlib.h>
 
 enum A
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint64_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   a1 = 0,
   a2 = 2,
@@ -28,13 +28,17 @@ enum A
   a4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint64_t A;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum B
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   b1 = 0,
   b2 = 2,
@@ -42,13 +46,17 @@ enum B
   b4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint32_t B;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum C
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint16_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   c1 = 0,
   c2 = 2,
@@ -56,13 +64,17 @@ enum C
   c4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint16_t C;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum D
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   d1 = 0,
   d2 = 2,
@@ -70,13 +82,17 @@ enum D
   d4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum D D;
+#else
 typedef uint8_t D;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum E
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uintptr_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   e1 = 0,
   e2 = 2,
@@ -84,13 +100,17 @@ enum E
   e4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum E E;
+#else
 typedef uintptr_t E;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum F
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : intptr_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   f1 = 0,
   f2 = 2,
@@ -98,7 +118,11 @@ enum F
   f4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F F;
+#else
 typedef intptr_t F;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef enum {
@@ -109,16 +133,20 @@ typedef enum {
 } L;
 
 enum M
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   m1 = -1,
   m2 = 0,
   m3 = 1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum M M;
+#else
 typedef int8_t M;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef enum {
@@ -129,9 +157,9 @@ typedef enum {
 } N;
 
 enum O
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   o1,
   o2,
@@ -139,7 +167,11 @@ enum O
   o4,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum O O;
+#else
 typedef int8_t O;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct J J;
@@ -149,16 +181,20 @@ typedef struct K K;
 typedef struct Opaque Opaque;
 
 enum G_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
   Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum G_Tag G_Tag;
+#else
 typedef uint8_t G_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -198,16 +234,20 @@ typedef struct {
 } H;
 
 enum ExI_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   ExI_Foo,
   ExI_Bar,
   ExI_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum ExI_Tag ExI_Tag;
+#else
 typedef uint8_t ExI_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -226,15 +266,19 @@ typedef struct {
 } ExI;
 
 enum P_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   P0,
   P1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum P_Tag P_Tag;
+#else
 typedef uint8_t P_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/enum_both.c
+++ b/tests/expectations/enum_both.c
@@ -17,53 +17,101 @@ using Box = T*;
 #include <stdint.h>
 #include <stdlib.h>
 
-enum A {
+enum A
+#if __STDC_VERSION__ >= 202311L
+  : uint64_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   a1 = 0,
   a2 = 2,
   a3,
   a4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint64_t A;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum B {
+enum B
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   b1 = 0,
   b2 = 2,
   b3,
   b4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint32_t B;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum C {
+enum C
+#if __STDC_VERSION__ >= 202311L
+  : uint16_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   c1 = 0,
   c2 = 2,
   c3,
   c4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint16_t C;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum D {
+enum D
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   d1 = 0,
   d2 = 2,
   d3,
   d4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum D D;
+#else
 typedef uint8_t D;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum E {
+enum E
+#if __STDC_VERSION__ >= 202311L
+  : uintptr_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   e1 = 0,
   e2 = 2,
   e3,
   e4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum E E;
+#else
 typedef uintptr_t E;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum F {
+enum F
+#if __STDC_VERSION__ >= 202311L
+  : intptr_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   f1 = 0,
   f2 = 2,
   f3,
   f4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F F;
+#else
 typedef intptr_t F;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef enum L {
   l1,
@@ -72,12 +120,20 @@ typedef enum L {
   l4,
 } L;
 
-enum M {
+enum M
+#if __STDC_VERSION__ >= 202311L
+  : int8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   m1 = -1,
   m2 = 0,
   m3 = 1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum M M;
+#else
 typedef int8_t M;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef enum N {
   n1,
@@ -86,13 +142,21 @@ typedef enum N {
   n4,
 } N;
 
-enum O {
+enum O
+#if __STDC_VERSION__ >= 202311L
+  : int8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   o1,
   o2,
   o3,
   o4,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum O O;
+#else
 typedef int8_t O;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct J J;
 
@@ -100,12 +164,20 @@ typedef struct K K;
 
 typedef struct Opaque Opaque;
 
-enum G_Tag {
+enum G_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
   Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum G_Tag G_Tag;
+#else
 typedef uint8_t G_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct Bar_Body {
   G_Tag tag;
@@ -143,12 +215,20 @@ typedef struct H {
   };
 } H;
 
-enum ExI_Tag {
+enum ExI_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   ExI_Foo,
   ExI_Bar,
   ExI_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum ExI_Tag ExI_Tag;
+#else
 typedef uint8_t ExI_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct ExI_Bar_Body {
   uint8_t x;
@@ -165,11 +245,19 @@ typedef struct ExI {
   };
 } ExI;
 
-enum P_Tag {
+enum P_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   P0,
   P1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum P_Tag P_Tag;
+#else
 typedef uint8_t P_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct P1_Body {
   uint8_t _0;

--- a/tests/expectations/enum_both.compat.c
+++ b/tests/expectations/enum_both.compat.c
@@ -18,9 +18,9 @@ using Box = T*;
 #include <stdlib.h>
 
 enum A
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint64_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   a1 = 0,
   a2 = 2,
@@ -28,13 +28,17 @@ enum A
   a4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint64_t A;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum B
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   b1 = 0,
   b2 = 2,
@@ -42,13 +46,17 @@ enum B
   b4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint32_t B;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum C
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint16_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   c1 = 0,
   c2 = 2,
@@ -56,13 +64,17 @@ enum C
   c4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint16_t C;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum D
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   d1 = 0,
   d2 = 2,
@@ -70,13 +82,17 @@ enum D
   d4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum D D;
+#else
 typedef uint8_t D;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum E
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uintptr_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   e1 = 0,
   e2 = 2,
@@ -84,13 +100,17 @@ enum E
   e4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum E E;
+#else
 typedef uintptr_t E;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum F
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : intptr_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   f1 = 0,
   f2 = 2,
@@ -98,7 +118,11 @@ enum F
   f4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F F;
+#else
 typedef intptr_t F;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef enum L {
@@ -109,16 +133,20 @@ typedef enum L {
 } L;
 
 enum M
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   m1 = -1,
   m2 = 0,
   m3 = 1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum M M;
+#else
 typedef int8_t M;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef enum N {
@@ -129,9 +157,9 @@ typedef enum N {
 } N;
 
 enum O
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   o1,
   o2,
@@ -139,7 +167,11 @@ enum O
   o4,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum O O;
+#else
 typedef int8_t O;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct J J;
@@ -149,16 +181,20 @@ typedef struct K K;
 typedef struct Opaque Opaque;
 
 enum G_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
   Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum G_Tag G_Tag;
+#else
 typedef uint8_t G_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct Bar_Body {
@@ -198,16 +234,20 @@ typedef struct H {
 } H;
 
 enum ExI_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   ExI_Foo,
   ExI_Bar,
   ExI_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum ExI_Tag ExI_Tag;
+#else
 typedef uint8_t ExI_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct ExI_Bar_Body {
@@ -226,15 +266,19 @@ typedef struct ExI {
 } ExI;
 
 enum P_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   P0,
   P1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum P_Tag P_Tag;
+#else
 typedef uint8_t P_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct P1_Body {

--- a/tests/expectations/enum_discriminant.c
+++ b/tests/expectations/enum_discriminant.c
@@ -5,7 +5,11 @@
 
 #define FOURTY_FOUR 4
 
-enum E {
+enum E
+#if __STDC_VERSION__ >= 202311L
+  : int8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A = 1,
   B = -1,
   C = (1 + 2),
@@ -14,6 +18,10 @@ enum E {
   G = (int8_t)54,
   H = (int8_t)false,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum E E;
+#else
 typedef int8_t E;
+#endif // __STDC_VERSION__ >= 202311L
 
 void root(const E*);

--- a/tests/expectations/enum_discriminant.compat.c
+++ b/tests/expectations/enum_discriminant.compat.c
@@ -6,9 +6,9 @@
 #define FOURTY_FOUR 4
 
 enum E
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A = 1,
   B = -1,
@@ -19,7 +19,11 @@ enum E
   H = (int8_t)false,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum E E;
+#else
 typedef int8_t E;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 #ifdef __cplusplus

--- a/tests/expectations/enum_self.c
+++ b/tests/expectations/enum_self.c
@@ -7,12 +7,20 @@ typedef struct {
   const int32_t *something;
 } Foo_Bar;
 
-enum Bar_Tag {
+enum Bar_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Min,
   Max,
   Other,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union {
   Bar_Tag tag;

--- a/tests/expectations/enum_self.compat.c
+++ b/tests/expectations/enum_self.compat.c
@@ -8,16 +8,20 @@ typedef struct {
 } Foo_Bar;
 
 enum Bar_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Min,
   Max,
   Other,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union {

--- a/tests/expectations/enum_self_both.c
+++ b/tests/expectations/enum_self_both.c
@@ -7,12 +7,20 @@ typedef struct Foo_Bar {
   const int32_t *something;
 } Foo_Bar;
 
-enum Bar_Tag {
+enum Bar_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Min,
   Max,
   Other,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union Bar {
   Bar_Tag tag;

--- a/tests/expectations/enum_self_both.compat.c
+++ b/tests/expectations/enum_self_both.compat.c
@@ -8,16 +8,20 @@ typedef struct Foo_Bar {
 } Foo_Bar;
 
 enum Bar_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Min,
   Max,
   Other,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union Bar {

--- a/tests/expectations/enum_self_flags.c
+++ b/tests/expectations/enum_self_flags.c
@@ -22,7 +22,11 @@
  * Specifies which tracks(s) on the axis that the position-area span occupies.
  * Represented as 3 bits: start, center, end track.
  */
-enum PositionAreaTrack {
+enum PositionAreaTrack
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   /**
    * First track
    */
@@ -48,14 +52,22 @@ enum PositionAreaTrack {
    */
   SpanAll = 7,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum PositionAreaTrack PositionAreaTrack;
+#else
 typedef uint8_t PositionAreaTrack;
+#endif // __STDC_VERSION__ >= 202311L
 
 /**
  * A three-bit value that represents the axis in which position-area operates on.
  * Represented as 3 bits: axis type (physical or logical), direction type (physical or logical),
  * axis value.
  */
-enum PositionAreaAxis {
+enum PositionAreaAxis
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Horizontal = 0,
   Vertical = 1,
   X = 2,
@@ -63,7 +75,11 @@ enum PositionAreaAxis {
   Inline = 6,
   Block = 7,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum PositionAreaAxis PositionAreaAxis;
+#else
 typedef uint8_t PositionAreaAxis;
+#endif // __STDC_VERSION__ >= 202311L
 
 /**
  * Possible values for the `position-area` property's keywords.
@@ -71,7 +87,11 @@ typedef uint8_t PositionAreaAxis;
  * PositionAreaAxis and yyy is the PositionAreaTrack
  * https://drafts.csswg.org/css-anchor-position-1/#propdef-position-area
  */
-enum PositionAreaKeyword {
+enum PositionAreaKeyword
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   None = 0,
   Center = (uint8_t)PositionAreaTrack_Center,
   SpanAll = (uint8_t)PositionAreaTrack_SpanAll,
@@ -82,7 +102,11 @@ enum PositionAreaKeyword {
   Top = (((uint8_t)PositionAreaAxis_Vertical << AXIS_SHIFT) | (uint8_t)PositionAreaTrack_Start),
   Bottom = (((uint8_t)PositionAreaAxis_Vertical << AXIS_SHIFT) | (uint8_t)PositionAreaTrack_End),
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum PositionAreaKeyword PositionAreaKeyword;
+#else
 typedef uint8_t PositionAreaKeyword;
+#endif // __STDC_VERSION__ >= 202311L
 
 void root(PositionAreaKeyword, PositionAreaTrack, PositionAreaAxis);
 

--- a/tests/expectations/enum_self_flags.compat.c
+++ b/tests/expectations/enum_self_flags.compat.c
@@ -23,9 +23,9 @@
  * Represented as 3 bits: start, center, end track.
  */
 enum PositionAreaTrack
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   /**
    * First track
@@ -53,7 +53,11 @@ enum PositionAreaTrack
   SpanAll = 7,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum PositionAreaTrack PositionAreaTrack;
+#else
 typedef uint8_t PositionAreaTrack;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 /**
@@ -62,9 +66,9 @@ typedef uint8_t PositionAreaTrack;
  * axis value.
  */
 enum PositionAreaAxis
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Horizontal = 0,
   Vertical = 1,
@@ -74,7 +78,11 @@ enum PositionAreaAxis
   Block = 7,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum PositionAreaAxis PositionAreaAxis;
+#else
 typedef uint8_t PositionAreaAxis;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 /**
@@ -84,9 +92,9 @@ typedef uint8_t PositionAreaAxis;
  * https://drafts.csswg.org/css-anchor-position-1/#propdef-position-area
  */
 enum PositionAreaKeyword
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   None = 0,
   Center = (uint8_t)PositionAreaTrack_Center,
@@ -99,7 +107,11 @@ enum PositionAreaKeyword
   Bottom = (((uint8_t)PositionAreaAxis_Vertical << AXIS_SHIFT) | (uint8_t)PositionAreaTrack_End),
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum PositionAreaKeyword PositionAreaKeyword;
+#else
 typedef uint8_t PositionAreaKeyword;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 #ifdef __cplusplus

--- a/tests/expectations/enum_self_tag.c
+++ b/tests/expectations/enum_self_tag.c
@@ -7,12 +7,20 @@ struct Foo_Bar {
   const int32_t *something;
 };
 
-enum Bar_Tag {
+enum Bar_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Min,
   Max,
   Other,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 union Bar {
   Bar_Tag tag;

--- a/tests/expectations/enum_self_tag.compat.c
+++ b/tests/expectations/enum_self_tag.compat.c
@@ -8,16 +8,20 @@ struct Foo_Bar {
 };
 
 enum Bar_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Min,
   Max,
   Other,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Bar_Tag Bar_Tag;
+#else
 typedef uint8_t Bar_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 union Bar {

--- a/tests/expectations/enum_tag.c
+++ b/tests/expectations/enum_tag.c
@@ -17,53 +17,101 @@ using Box = T*;
 #include <stdint.h>
 #include <stdlib.h>
 
-enum A {
+enum A
+#if __STDC_VERSION__ >= 202311L
+  : uint64_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   a1 = 0,
   a2 = 2,
   a3,
   a4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint64_t A;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum B {
+enum B
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   b1 = 0,
   b2 = 2,
   b3,
   b4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint32_t B;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum C {
+enum C
+#if __STDC_VERSION__ >= 202311L
+  : uint16_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   c1 = 0,
   c2 = 2,
   c3,
   c4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint16_t C;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum D {
+enum D
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   d1 = 0,
   d2 = 2,
   d3,
   d4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum D D;
+#else
 typedef uint8_t D;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum E {
+enum E
+#if __STDC_VERSION__ >= 202311L
+  : uintptr_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   e1 = 0,
   e2 = 2,
   e3,
   e4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum E E;
+#else
 typedef uintptr_t E;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum F {
+enum F
+#if __STDC_VERSION__ >= 202311L
+  : intptr_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   f1 = 0,
   f2 = 2,
   f3,
   f4 = 5,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F F;
+#else
 typedef intptr_t F;
+#endif // __STDC_VERSION__ >= 202311L
 
 enum L {
   l1,
@@ -72,12 +120,20 @@ enum L {
   l4,
 };
 
-enum M {
+enum M
+#if __STDC_VERSION__ >= 202311L
+  : int8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   m1 = -1,
   m2 = 0,
   m3 = 1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum M M;
+#else
 typedef int8_t M;
+#endif // __STDC_VERSION__ >= 202311L
 
 enum N {
   n1,
@@ -86,13 +142,21 @@ enum N {
   n4,
 };
 
-enum O {
+enum O
+#if __STDC_VERSION__ >= 202311L
+  : int8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   o1,
   o2,
   o3,
   o4,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum O O;
+#else
 typedef int8_t O;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct J;
 
@@ -100,12 +164,20 @@ struct K;
 
 struct Opaque;
 
-enum G_Tag {
+enum G_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
   Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum G_Tag G_Tag;
+#else
 typedef uint8_t G_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct Bar_Body {
   G_Tag tag;
@@ -143,12 +215,20 @@ struct H {
   };
 };
 
-enum ExI_Tag {
+enum ExI_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   ExI_Foo,
   ExI_Bar,
   ExI_Baz,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum ExI_Tag ExI_Tag;
+#else
 typedef uint8_t ExI_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct ExI_Bar_Body {
   uint8_t x;
@@ -165,11 +245,19 @@ struct ExI {
   };
 };
 
-enum P_Tag {
+enum P_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   P0,
   P1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum P_Tag P_Tag;
+#else
 typedef uint8_t P_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct P1_Body {
   uint8_t _0;

--- a/tests/expectations/enum_tag.compat.c
+++ b/tests/expectations/enum_tag.compat.c
@@ -18,9 +18,9 @@ using Box = T*;
 #include <stdlib.h>
 
 enum A
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint64_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   a1 = 0,
   a2 = 2,
@@ -28,13 +28,17 @@ enum A
   a4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint64_t A;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum B
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint32_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   b1 = 0,
   b2 = 2,
@@ -42,13 +46,17 @@ enum B
   b4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint32_t B;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum C
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint16_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   c1 = 0,
   c2 = 2,
@@ -56,13 +64,17 @@ enum C
   c4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C C;
+#else
 typedef uint16_t C;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum D
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   d1 = 0,
   d2 = 2,
@@ -70,13 +82,17 @@ enum D
   d4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum D D;
+#else
 typedef uint8_t D;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum E
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uintptr_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   e1 = 0,
   e2 = 2,
@@ -84,13 +100,17 @@ enum E
   e4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum E E;
+#else
 typedef uintptr_t E;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum F
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : intptr_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   f1 = 0,
   f2 = 2,
@@ -98,7 +118,11 @@ enum F
   f4 = 5,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F F;
+#else
 typedef intptr_t F;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum L {
@@ -109,16 +133,20 @@ enum L {
 };
 
 enum M
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   m1 = -1,
   m2 = 0,
   m3 = 1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum M M;
+#else
 typedef int8_t M;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum N {
@@ -129,9 +157,9 @@ enum N {
 };
 
 enum O
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : int8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   o1,
   o2,
@@ -139,7 +167,11 @@ enum O
   o4,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum O O;
+#else
 typedef int8_t O;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct J;
@@ -149,16 +181,20 @@ struct K;
 struct Opaque;
 
 enum G_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
   Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum G_Tag G_Tag;
+#else
 typedef uint8_t G_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct Bar_Body {
@@ -198,16 +234,20 @@ struct H {
 };
 
 enum ExI_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   ExI_Foo,
   ExI_Bar,
   ExI_Baz,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum ExI_Tag ExI_Tag;
+#else
 typedef uint8_t ExI_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct ExI_Bar_Body {
@@ -226,15 +266,19 @@ struct ExI {
 };
 
 enum P_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   P0,
   P1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum P_Tag P_Tag;
+#else
 typedef uint8_t P_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct P1_Body {

--- a/tests/expectations/item_types.c
+++ b/tests/expectations/item_types.c
@@ -3,8 +3,16 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum OnlyThisShouldBeGenerated {
+enum OnlyThisShouldBeGenerated
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum OnlyThisShouldBeGenerated OnlyThisShouldBeGenerated;
+#else
 typedef uint8_t OnlyThisShouldBeGenerated;
+#endif // __STDC_VERSION__ >= 202311L

--- a/tests/expectations/item_types.compat.c
+++ b/tests/expectations/item_types.compat.c
@@ -4,13 +4,17 @@
 #include <stdlib.h>
 
 enum OnlyThisShouldBeGenerated
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum OnlyThisShouldBeGenerated OnlyThisShouldBeGenerated;
+#else
 typedef uint8_t OnlyThisShouldBeGenerated;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus

--- a/tests/expectations/item_types_renamed.c
+++ b/tests/expectations/item_types_renamed.c
@@ -3,8 +3,16 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum StyleOnlyThisShouldBeGenerated {
+enum StyleOnlyThisShouldBeGenerated
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo,
   Bar,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleOnlyThisShouldBeGenerated StyleOnlyThisShouldBeGenerated;
+#else
 typedef uint8_t StyleOnlyThisShouldBeGenerated;
+#endif // __STDC_VERSION__ >= 202311L

--- a/tests/expectations/item_types_renamed.compat.c
+++ b/tests/expectations/item_types_renamed.compat.c
@@ -4,13 +4,17 @@
 #include <stdlib.h>
 
 enum StyleOnlyThisShouldBeGenerated
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo,
   Bar,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleOnlyThisShouldBeGenerated StyleOnlyThisShouldBeGenerated;
+#else
 typedef uint8_t StyleOnlyThisShouldBeGenerated;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus

--- a/tests/expectations/must_use.c
+++ b/tests/expectations/must_use.c
@@ -8,11 +8,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum MaybeOwnedPtr_i32_Tag {
+enum MaybeOwnedPtr_i32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Owned_i32,
   None_i32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum MaybeOwnedPtr_i32_Tag MaybeOwnedPtr_i32_Tag;
+#else
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct MUST_USE_STRUCT {
   MaybeOwnedPtr_i32_Tag tag;

--- a/tests/expectations/must_use.compat.c
+++ b/tests/expectations/must_use.compat.c
@@ -9,15 +9,19 @@
 #include <stdlib.h>
 
 enum MaybeOwnedPtr_i32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Owned_i32,
   None_i32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum MaybeOwnedPtr_i32_Tag MaybeOwnedPtr_i32_Tag;
+#else
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct MUST_USE_STRUCT {

--- a/tests/expectations/must_use_both.c
+++ b/tests/expectations/must_use_both.c
@@ -8,11 +8,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum MaybeOwnedPtr_i32_Tag {
+enum MaybeOwnedPtr_i32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Owned_i32,
   None_i32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum MaybeOwnedPtr_i32_Tag MaybeOwnedPtr_i32_Tag;
+#else
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;

--- a/tests/expectations/must_use_both.compat.c
+++ b/tests/expectations/must_use_both.compat.c
@@ -9,15 +9,19 @@
 #include <stdlib.h>
 
 enum MaybeOwnedPtr_i32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Owned_i32,
   None_i32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum MaybeOwnedPtr_i32_Tag MaybeOwnedPtr_i32_Tag;
+#else
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {

--- a/tests/expectations/must_use_tag.c
+++ b/tests/expectations/must_use_tag.c
@@ -8,11 +8,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum MaybeOwnedPtr_i32_Tag {
+enum MaybeOwnedPtr_i32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Owned_i32,
   None_i32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum MaybeOwnedPtr_i32_Tag MaybeOwnedPtr_i32_Tag;
+#else
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {
   MaybeOwnedPtr_i32_Tag tag;

--- a/tests/expectations/must_use_tag.compat.c
+++ b/tests/expectations/must_use_tag.compat.c
@@ -9,15 +9,19 @@
 #include <stdlib.h>
 
 enum MaybeOwnedPtr_i32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Owned_i32,
   None_i32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum MaybeOwnedPtr_i32_Tag MaybeOwnedPtr_i32_Tag;
+#else
 typedef uint8_t MaybeOwnedPtr_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct MUST_USE_STRUCT MaybeOwnedPtr_i32 {

--- a/tests/expectations/prefix.c
+++ b/tests/expectations/prefix.c
@@ -13,12 +13,20 @@ typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
 typedef int32_t PREFIX_ValuedLenArray[22];
 
-enum PREFIX_AbsoluteFontWeight_Tag {
+enum PREFIX_AbsoluteFontWeight_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Weight,
   Normal,
   Bold,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum PREFIX_AbsoluteFontWeight_Tag PREFIX_AbsoluteFontWeight_Tag;
+#else
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union {
   PREFIX_AbsoluteFontWeight_Tag tag;

--- a/tests/expectations/prefix.compat.c
+++ b/tests/expectations/prefix.compat.c
@@ -14,16 +14,20 @@ typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 typedef int32_t PREFIX_ValuedLenArray[22];
 
 enum PREFIX_AbsoluteFontWeight_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Weight,
   Normal,
   Bold,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum PREFIX_AbsoluteFontWeight_Tag PREFIX_AbsoluteFontWeight_Tag;
+#else
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union {

--- a/tests/expectations/prefix_both.c
+++ b/tests/expectations/prefix_both.c
@@ -13,12 +13,20 @@ typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
 typedef int32_t PREFIX_ValuedLenArray[22];
 
-enum PREFIX_AbsoluteFontWeight_Tag {
+enum PREFIX_AbsoluteFontWeight_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Weight,
   Normal,
   Bold,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum PREFIX_AbsoluteFontWeight_Tag PREFIX_AbsoluteFontWeight_Tag;
+#else
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union PREFIX_AbsoluteFontWeight {
   PREFIX_AbsoluteFontWeight_Tag tag;

--- a/tests/expectations/prefix_both.compat.c
+++ b/tests/expectations/prefix_both.compat.c
@@ -14,16 +14,20 @@ typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 typedef int32_t PREFIX_ValuedLenArray[22];
 
 enum PREFIX_AbsoluteFontWeight_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Weight,
   Normal,
   Bold,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum PREFIX_AbsoluteFontWeight_Tag PREFIX_AbsoluteFontWeight_Tag;
+#else
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union PREFIX_AbsoluteFontWeight {

--- a/tests/expectations/prefix_tag.c
+++ b/tests/expectations/prefix_tag.c
@@ -13,12 +13,20 @@ typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 
 typedef int32_t PREFIX_ValuedLenArray[22];
 
-enum PREFIX_AbsoluteFontWeight_Tag {
+enum PREFIX_AbsoluteFontWeight_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Weight,
   Normal,
   Bold,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum PREFIX_AbsoluteFontWeight_Tag PREFIX_AbsoluteFontWeight_Tag;
+#else
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 union PREFIX_AbsoluteFontWeight {
   PREFIX_AbsoluteFontWeight_Tag tag;

--- a/tests/expectations/prefix_tag.compat.c
+++ b/tests/expectations/prefix_tag.compat.c
@@ -14,16 +14,20 @@ typedef int32_t PREFIX_NamedLenArray[PREFIX_LEN];
 typedef int32_t PREFIX_ValuedLenArray[22];
 
 enum PREFIX_AbsoluteFontWeight_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Weight,
   Normal,
   Bold,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum PREFIX_AbsoluteFontWeight_Tag PREFIX_AbsoluteFontWeight_Tag;
+#else
 typedef uint8_t PREFIX_AbsoluteFontWeight_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 union PREFIX_AbsoluteFontWeight {

--- a/tests/expectations/raw_ident.c
+++ b/tests/expectations/raw_ident.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum Enum {
+enum Enum
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   a,
   b,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Enum Enum;
+#else
 typedef uint8_t Enum;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   Enum field;

--- a/tests/expectations/raw_ident.compat.c
+++ b/tests/expectations/raw_ident.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum Enum
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   a,
   b,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Enum Enum;
+#else
 typedef uint8_t Enum;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/raw_ident_both.c
+++ b/tests/expectations/raw_ident_both.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum Enum {
+enum Enum
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   a,
   b,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Enum Enum;
+#else
 typedef uint8_t Enum;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct Struct {
   Enum field;

--- a/tests/expectations/raw_ident_both.compat.c
+++ b/tests/expectations/raw_ident_both.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum Enum
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   a,
   b,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Enum Enum;
+#else
 typedef uint8_t Enum;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct Struct {

--- a/tests/expectations/raw_ident_tag.c
+++ b/tests/expectations/raw_ident_tag.c
@@ -3,11 +3,19 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum Enum {
+enum Enum
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   a,
   b,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum Enum Enum;
+#else
 typedef uint8_t Enum;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct Struct {
   Enum field;

--- a/tests/expectations/raw_ident_tag.compat.c
+++ b/tests/expectations/raw_ident_tag.compat.c
@@ -4,15 +4,19 @@
 #include <stdlib.h>
 
 enum Enum
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   a,
   b,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum Enum Enum;
+#else
 typedef uint8_t Enum;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct Struct {

--- a/tests/expectations/rename.c
+++ b/tests/expectations/rename.c
@@ -5,11 +5,19 @@
 
 #define C_H 10
 
-enum C_E {
+enum C_E
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   x = 0,
   y = 1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_E C_E;
+#else
 typedef uint8_t C_E;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct C_A C_A;
 

--- a/tests/expectations/rename.compat.c
+++ b/tests/expectations/rename.compat.c
@@ -6,15 +6,19 @@
 #define C_H 10
 
 enum C_E
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   x = 0,
   y = 1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_E C_E;
+#else
 typedef uint8_t C_E;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct C_A C_A;

--- a/tests/expectations/rename_both.c
+++ b/tests/expectations/rename_both.c
@@ -5,11 +5,19 @@
 
 #define C_H 10
 
-enum C_E {
+enum C_E
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   x = 0,
   y = 1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_E C_E;
+#else
 typedef uint8_t C_E;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct C_A C_A;
 

--- a/tests/expectations/rename_both.compat.c
+++ b/tests/expectations/rename_both.compat.c
@@ -6,15 +6,19 @@
 #define C_H 10
 
 enum C_E
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   x = 0,
   y = 1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_E C_E;
+#else
 typedef uint8_t C_E;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct C_A C_A;

--- a/tests/expectations/rename_tag.c
+++ b/tests/expectations/rename_tag.c
@@ -5,11 +5,19 @@
 
 #define C_H 10
 
-enum C_E {
+enum C_E
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   x = 0,
   y = 1,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_E C_E;
+#else
 typedef uint8_t C_E;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct C_A;
 

--- a/tests/expectations/rename_tag.compat.c
+++ b/tests/expectations/rename_tag.compat.c
@@ -6,15 +6,19 @@
 #define C_H 10
 
 enum C_E
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   x = 0,
   y = 1,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_E C_E;
+#else
 typedef uint8_t C_E;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct C_A;

--- a/tests/expectations/reserved.c
+++ b/tests/expectations/reserved.c
@@ -13,10 +13,18 @@ typedef struct {
   float float_;
 } B;
 
-enum C_Tag {
+enum C_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   D,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   int32_t namespace_;
@@ -30,11 +38,19 @@ typedef struct {
   };
 } C;
 
-enum E_Tag {
+enum E_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Double,
   Float,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum E_Tag E_Tag;
+#else
 typedef uint8_t E_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   E_Tag tag;
@@ -48,11 +64,19 @@ typedef struct {
   };
 } E;
 
-enum F_Tag {
+enum F_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   double_,
   float_,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   F_Tag tag;

--- a/tests/expectations/reserved.compat.c
+++ b/tests/expectations/reserved.compat.c
@@ -14,14 +14,18 @@ typedef struct {
 } B;
 
 enum C_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   D,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -37,15 +41,19 @@ typedef struct {
 } C;
 
 enum E_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Double,
   Float,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum E_Tag E_Tag;
+#else
 typedef uint8_t E_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -61,15 +69,19 @@ typedef struct {
 } E;
 
 enum F_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   double_,
   float_,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/reserved_both.c
+++ b/tests/expectations/reserved_both.c
@@ -13,10 +13,18 @@ typedef struct B {
   float float_;
 } B;
 
-enum C_Tag {
+enum C_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   D,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct D_Body {
   int32_t namespace_;
@@ -30,11 +38,19 @@ typedef struct C {
   };
 } C;
 
-enum E_Tag {
+enum E_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Double,
   Float,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum E_Tag E_Tag;
+#else
 typedef uint8_t E_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct E {
   E_Tag tag;
@@ -48,11 +64,19 @@ typedef struct E {
   };
 } E;
 
-enum F_Tag {
+enum F_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   double_,
   float_,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct F {
   F_Tag tag;

--- a/tests/expectations/reserved_both.compat.c
+++ b/tests/expectations/reserved_both.compat.c
@@ -14,14 +14,18 @@ typedef struct B {
 } B;
 
 enum C_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   D,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct D_Body {
@@ -37,15 +41,19 @@ typedef struct C {
 } C;
 
 enum E_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Double,
   Float,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum E_Tag E_Tag;
+#else
 typedef uint8_t E_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct E {
@@ -61,15 +69,19 @@ typedef struct E {
 } E;
 
 enum F_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   double_,
   float_,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct F {

--- a/tests/expectations/reserved_tag.c
+++ b/tests/expectations/reserved_tag.c
@@ -13,10 +13,18 @@ struct B {
   float float_;
 };
 
-enum C_Tag {
+enum C_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   D,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct D_Body {
   int32_t namespace_;
@@ -30,11 +38,19 @@ struct C {
   };
 };
 
-enum E_Tag {
+enum E_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Double,
   Float,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum E_Tag E_Tag;
+#else
 typedef uint8_t E_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct E {
   E_Tag tag;
@@ -48,11 +64,19 @@ struct E {
   };
 };
 
-enum F_Tag {
+enum F_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   double_,
   float_,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct F {
   F_Tag tag;

--- a/tests/expectations/reserved_tag.compat.c
+++ b/tests/expectations/reserved_tag.compat.c
@@ -14,14 +14,18 @@ struct B {
 };
 
 enum C_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   D,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct D_Body {
@@ -37,15 +41,19 @@ struct C {
 };
 
 enum E_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Double,
   Float,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum E_Tag E_Tag;
+#else
 typedef uint8_t E_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct E {
@@ -61,15 +69,19 @@ struct E {
 };
 
 enum F_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   double_,
   float_,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum F_Tag F_Tag;
+#else
 typedef uint8_t F_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct F {

--- a/tests/expectations/sentinel.c
+++ b/tests/expectations/sentinel.c
@@ -3,7 +3,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum A {
+enum A
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A_A1,
   A_A2,
   A_A3,
@@ -12,9 +16,17 @@ enum A {
    */
   A_Sentinel,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint8_t A;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum B {
+enum B
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   B_B1,
   B_B2,
   B_B3,
@@ -23,9 +35,17 @@ enum B {
    */
   B_Sentinel,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint8_t B;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum C_Tag {
+enum C_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   C_C1,
   C_C2,
   C_C3,
@@ -34,7 +54,11 @@ enum C_Tag {
    */
   C_Sentinel,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   C_Tag tag;

--- a/tests/expectations/sentinel.compat.c
+++ b/tests/expectations/sentinel.compat.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 enum A
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A_A1,
   A_A2,
@@ -17,13 +17,17 @@ enum A
   A_Sentinel,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint8_t A;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum B
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   B_B1,
   B_B2,
@@ -34,13 +38,17 @@ enum B
   B_Sentinel,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint8_t B;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum C_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   C_C1,
   C_C2,
@@ -51,7 +59,11 @@ enum C_Tag
   C_Sentinel,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/sentinel_both.c
+++ b/tests/expectations/sentinel_both.c
@@ -3,7 +3,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum A {
+enum A
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A_A1,
   A_A2,
   A_A3,
@@ -12,9 +16,17 @@ enum A {
    */
   A_Sentinel,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint8_t A;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum B {
+enum B
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   B_B1,
   B_B2,
   B_B3,
@@ -23,9 +35,17 @@ enum B {
    */
   B_Sentinel,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint8_t B;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum C_Tag {
+enum C_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   C_C1,
   C_C2,
   C_C3,
@@ -34,7 +54,11 @@ enum C_Tag {
    */
   C_Sentinel,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct C_C1_Body {
   C_Tag tag;

--- a/tests/expectations/sentinel_both.compat.c
+++ b/tests/expectations/sentinel_both.compat.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 enum A
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A_A1,
   A_A2,
@@ -17,13 +17,17 @@ enum A
   A_Sentinel,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint8_t A;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum B
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   B_B1,
   B_B2,
@@ -34,13 +38,17 @@ enum B
   B_Sentinel,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint8_t B;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum C_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   C_C1,
   C_C2,
@@ -51,7 +59,11 @@ enum C_Tag
   C_Sentinel,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct C_C1_Body {

--- a/tests/expectations/sentinel_tag.c
+++ b/tests/expectations/sentinel_tag.c
@@ -3,7 +3,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum A {
+enum A
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   A_A1,
   A_A2,
   A_A3,
@@ -12,9 +16,17 @@ enum A {
    */
   A_Sentinel,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint8_t A;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum B {
+enum B
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   B_B1,
   B_B2,
   B_B3,
@@ -23,9 +35,17 @@ enum B {
    */
   B_Sentinel,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint8_t B;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum C_Tag {
+enum C_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   C_C1,
   C_C2,
   C_C3,
@@ -34,7 +54,11 @@ enum C_Tag {
    */
   C_Sentinel,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct C_C1_Body {
   C_Tag tag;

--- a/tests/expectations/sentinel_tag.compat.c
+++ b/tests/expectations/sentinel_tag.compat.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 
 enum A
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   A_A1,
   A_A2,
@@ -17,13 +17,17 @@ enum A
   A_Sentinel,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum A A;
+#else
 typedef uint8_t A;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum B
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   B_B1,
   B_B2,
@@ -34,13 +38,17 @@ enum B
   B_Sentinel,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum B B;
+#else
 typedef uint8_t B;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum C_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   C_C1,
   C_C2,
@@ -51,7 +59,11 @@ enum C_Tag
   C_Sentinel,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum C_Tag C_Tag;
+#else
 typedef uint8_t C_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct C_C1_Body {

--- a/tests/expectations/size_types.c
+++ b/tests/expectations/size_types.c
@@ -4,15 +4,31 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-enum UE {
+enum UE
+#if __STDC_VERSION__ >= 202311L
+  : size_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   UV,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum UE UE;
+#else
 typedef size_t UE;
+#endif // __STDC_VERSION__ >= 202311L
 
-enum IE {
+enum IE
+#if __STDC_VERSION__ >= 202311L
+  : ptrdiff_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   IV,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum IE IE;
+#else
 typedef ptrdiff_t IE;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef size_t Usize;
 

--- a/tests/expectations/size_types.compat.c
+++ b/tests/expectations/size_types.compat.c
@@ -5,25 +5,33 @@
 #include <stdlib.h>
 
 enum UE
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : size_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   UV,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum UE UE;
+#else
 typedef size_t UE;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 enum IE
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : ptrdiff_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   IV,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum IE IE;
+#else
 typedef ptrdiff_t IE;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef size_t Usize;

--- a/tests/expectations/transform_op.c
+++ b/tests/expectations/transform_op.c
@@ -13,13 +13,21 @@ typedef struct {
   float y;
 } StylePoint_f32;
 
-enum StyleFoo_i32_Tag {
+enum StyleFoo_i32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo_i32,
   Bar_i32,
   Baz_i32,
   Bazz_i32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleFoo_i32_Tag StyleFoo_i32_Tag;
+#else
 typedef uint8_t StyleFoo_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   StyleFoo_i32_Tag tag;
@@ -100,12 +108,20 @@ typedef struct {
   };
 } StyleBar_u32;
 
-enum StyleBaz_Tag {
+enum StyleBaz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Baz1,
   Baz2,
   Baz3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleBaz_Tag StyleBaz_Tag;
+#else
 typedef uint8_t StyleBaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union {
   StyleBaz_Tag tag;
@@ -119,12 +135,20 @@ typedef union {
   };
 } StyleBaz;
 
-enum StyleTaz_Tag {
+enum StyleTaz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Taz1,
   Taz2,
   Taz3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleTaz_Tag StyleTaz_Tag;
+#else
 typedef uint8_t StyleTaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct {
   StyleTaz_Tag tag;

--- a/tests/expectations/transform_op.compat.c
+++ b/tests/expectations/transform_op.compat.c
@@ -14,9 +14,9 @@ typedef struct {
 } StylePoint_f32;
 
 enum StyleFoo_i32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo_i32,
   Bar_i32,
@@ -24,7 +24,11 @@ enum StyleFoo_i32_Tag
   Bazz_i32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleFoo_i32_Tag StyleFoo_i32_Tag;
+#else
 typedef uint8_t StyleFoo_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {
@@ -107,16 +111,20 @@ typedef struct {
 } StyleBar_u32;
 
 enum StyleBaz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Baz1,
   Baz2,
   Baz3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleBaz_Tag StyleBaz_Tag;
+#else
 typedef uint8_t StyleBaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union {
@@ -132,16 +140,20 @@ typedef union {
 } StyleBaz;
 
 enum StyleTaz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Taz1,
   Taz2,
   Taz3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleTaz_Tag StyleTaz_Tag;
+#else
 typedef uint8_t StyleTaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct {

--- a/tests/expectations/transform_op_both.c
+++ b/tests/expectations/transform_op_both.c
@@ -13,13 +13,21 @@ typedef struct StylePoint_f32 {
   float y;
 } StylePoint_f32;
 
-enum StyleFoo_i32_Tag {
+enum StyleFoo_i32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo_i32,
   Bar_i32,
   Baz_i32,
   Bazz_i32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleFoo_i32_Tag StyleFoo_i32_Tag;
+#else
 typedef uint8_t StyleFoo_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct StyleFoo_Body_i32 {
   StyleFoo_i32_Tag tag;
@@ -100,12 +108,20 @@ typedef struct StyleBar_u32 {
   };
 } StyleBar_u32;
 
-enum StyleBaz_Tag {
+enum StyleBaz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Baz1,
   Baz2,
   Baz3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleBaz_Tag StyleBaz_Tag;
+#else
 typedef uint8_t StyleBaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef union StyleBaz {
   StyleBaz_Tag tag;
@@ -119,12 +135,20 @@ typedef union StyleBaz {
   };
 } StyleBaz;
 
-enum StyleTaz_Tag {
+enum StyleTaz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Taz1,
   Taz2,
   Taz3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleTaz_Tag StyleTaz_Tag;
+#else
 typedef uint8_t StyleTaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 typedef struct StyleTaz {
   StyleTaz_Tag tag;

--- a/tests/expectations/transform_op_both.compat.c
+++ b/tests/expectations/transform_op_both.compat.c
@@ -14,9 +14,9 @@ typedef struct StylePoint_f32 {
 } StylePoint_f32;
 
 enum StyleFoo_i32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo_i32,
   Bar_i32,
@@ -24,7 +24,11 @@ enum StyleFoo_i32_Tag
   Bazz_i32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleFoo_i32_Tag StyleFoo_i32_Tag;
+#else
 typedef uint8_t StyleFoo_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct StyleFoo_Body_i32 {
@@ -107,16 +111,20 @@ typedef struct StyleBar_u32 {
 } StyleBar_u32;
 
 enum StyleBaz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Baz1,
   Baz2,
   Baz3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleBaz_Tag StyleBaz_Tag;
+#else
 typedef uint8_t StyleBaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef union StyleBaz {
@@ -132,16 +140,20 @@ typedef union StyleBaz {
 } StyleBaz;
 
 enum StyleTaz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Taz1,
   Taz2,
   Taz3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleTaz_Tag StyleTaz_Tag;
+#else
 typedef uint8_t StyleTaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 typedef struct StyleTaz {

--- a/tests/expectations/transform_op_tag.c
+++ b/tests/expectations/transform_op_tag.c
@@ -13,13 +13,21 @@ struct StylePoint_f32 {
   float y;
 };
 
-enum StyleFoo_i32_Tag {
+enum StyleFoo_i32_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Foo_i32,
   Bar_i32,
   Baz_i32,
   Bazz_i32,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleFoo_i32_Tag StyleFoo_i32_Tag;
+#else
 typedef uint8_t StyleFoo_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct StyleFoo_Body_i32 {
   StyleFoo_i32_Tag tag;
@@ -100,12 +108,20 @@ struct StyleBar_u32 {
   };
 };
 
-enum StyleBaz_Tag {
+enum StyleBaz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Baz1,
   Baz2,
   Baz3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleBaz_Tag StyleBaz_Tag;
+#else
 typedef uint8_t StyleBaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 union StyleBaz {
   StyleBaz_Tag tag;
@@ -119,12 +135,20 @@ union StyleBaz {
   };
 };
 
-enum StyleTaz_Tag {
+enum StyleTaz_Tag
+#if __STDC_VERSION__ >= 202311L
+  : uint8_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
   Taz1,
   Taz2,
   Taz3,
 };
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleTaz_Tag StyleTaz_Tag;
+#else
 typedef uint8_t StyleTaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 
 struct StyleTaz {
   StyleTaz_Tag tag;

--- a/tests/expectations/transform_op_tag.compat.c
+++ b/tests/expectations/transform_op_tag.compat.c
@@ -14,9 +14,9 @@ struct StylePoint_f32 {
 };
 
 enum StyleFoo_i32_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Foo_i32,
   Bar_i32,
@@ -24,7 +24,11 @@ enum StyleFoo_i32_Tag
   Bazz_i32,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleFoo_i32_Tag StyleFoo_i32_Tag;
+#else
 typedef uint8_t StyleFoo_i32_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct StyleFoo_Body_i32 {
@@ -107,16 +111,20 @@ struct StyleBar_u32 {
 };
 
 enum StyleBaz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Baz1,
   Baz2,
   Baz3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleBaz_Tag StyleBaz_Tag;
+#else
 typedef uint8_t StyleBaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 union StyleBaz {
@@ -132,16 +140,20 @@ union StyleBaz {
 };
 
 enum StyleTaz_Tag
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
   : uint8_t
-#endif // __cplusplus
+#endif // defined(__cplusplus) || __STDC_VERSION__ >= 202311L
  {
   Taz1,
   Taz2,
   Taz3,
 };
 #ifndef __cplusplus
+#if __STDC_VERSION__ >= 202311L
+typedef enum StyleTaz_Tag StyleTaz_Tag;
+#else
 typedef uint8_t StyleTaz_Tag;
+#endif // __STDC_VERSION__ >= 202311L
 #endif // __cplusplus
 
 struct StyleTaz {


### PR DESCRIPTION
C23 [has introduced support for enumerations with fixed underlying type](https://open-std.org/JTC1/SC22/WG14/www/docs/n3030.htm), matching the existing C++ syntax for this functionality.

This PR modifies cbindgen to output a header that enables this syntax if either `__cplusplus` is defined (as before) or if the compilation is according to C23 or later (added in this PR).

My motivation for this change is that my toolchain complained that some names were defined twice, both as an enum and a typedef.  I [fixed the error](https://github.com/Qiskit/Qiskit.jl/blob/73bfbb9440168dc76685632f9fb3d00d3a17bd79/gen/generator.jl#L16-L18) by defining `__cplusplus` even thought the compiler is compiling in C mode.  This change will allow me to remove that workaround, as long as C23 or later is set as the C standard.