### PR TITLE
Support cfg attributes on function arguments

### DIFF
--- a/src/bindgen/cdecl.rs
+++ b/src/bindgen/cdecl.rs
@@ -6,7 +6,9 @@ use std::io::Write;
 
 use crate::bindgen::config::Layout;
 use crate::bindgen::declarationtyperesolver::DeclarationType;
-use crate::bindgen::ir::{ConstExpr, Function, GenericArgument, Type};
+use crate::bindgen::ir::{
+    Condition, ConditionWrite, ConstExpr, Function, GenericArgument, ToCondition, Type,
+};
 use crate::bindgen::language_backend::LanguageBackend;
 use crate::bindgen::writer::{ListType, SourceWriter};
 use crate::bindgen::{Config, Language};
@@ -23,10 +25,16 @@ enum CDeclarator {
     },
     Array(String),
     Func {
-        args: Vec<(Option<String>, CDecl)>,
+        args: Vec<CFuncArg>,
         layout: Layout,
         never_return: bool,
     },
+}
+
+struct CFuncArg {
+    ident: Option<String>,
+    decl: CDecl,
+    condition: Option<Condition>,
 }
 
 impl CDeclarator {
@@ -90,11 +98,14 @@ impl CDecl {
         let args = f
             .args
             .iter()
-            .map(|arg| {
-                (
-                    arg.name.clone(),
-                    CDecl::from_func_arg(&arg.ty, arg.array_length.as_deref(), config),
-                )
+            .map(|arg| CFuncArg {
+                ident: arg.name.clone(),
+                decl: CDecl::from_func_arg(&arg.ty, arg.array_length.as_deref(), config),
+                condition: if config.language == Language::Cython {
+                    None
+                } else {
+                    arg.cfg.to_condition(config)
+                },
             })
             .collect();
         self.declarators.push(CDeclarator::Func {
@@ -170,7 +181,11 @@ impl CDecl {
             } => {
                 let args = args
                     .iter()
-                    .map(|(ref name, ref ty)| (name.clone(), CDecl::from_type(ty, config)))
+                    .map(|(ref name, ref ty)| CFuncArg {
+                        ident: name.clone(),
+                        decl: CDecl::from_type(ty, config),
+                        condition: None,
+                    })
                     .collect();
                 self.declarators.push(CDeclarator::Ptr {
                     is_const: false,
@@ -308,20 +323,18 @@ impl CDecl {
                         language_backend: &mut LB,
                         out: &mut SourceWriter<F>,
                         config: &Config,
-                        args: &[(Option<String>, CDecl)],
+                        args: &[CFuncArg],
                     ) {
                         let align_length = out.line_length_for_align();
                         out.push_set_spaces(align_length);
-                        for (i, (arg_ident, arg_ty)) in args.iter().enumerate() {
+                        for (i, arg) in args.iter().enumerate() {
                             if i != 0 {
                                 out.write(",");
                                 out.new_line();
                             }
 
-                            // Convert &Option<String> to Option<&str>
-                            let arg_ident = arg_ident.as_ref().map(|x| x.as_ref());
-
-                            arg_ty.write(language_backend, out, arg_ident, config);
+                            arg.decl
+                                .write(language_backend, out, arg.ident.as_deref(), config);
                         }
                         out.pop_tab();
                     }
@@ -330,29 +343,91 @@ impl CDecl {
                         language_backend: &mut LB,
                         out: &mut SourceWriter<F>,
                         config: &Config,
-                        args: &[(Option<String>, CDecl)],
+                        args: &[CFuncArg],
                     ) {
-                        for (i, (arg_ident, arg_ty)) in args.iter().enumerate() {
+                        for (i, arg) in args.iter().enumerate() {
                             if i != 0 {
                                 out.write(", ");
                             }
 
-                            // Convert &Option<String> to Option<&str>
-                            let arg_ident = arg_ident.as_ref().map(|x| x.as_ref());
-
-                            arg_ty.write(language_backend, out, arg_ident, config);
+                            arg.decl
+                                .write(language_backend, out, arg.ident.as_deref(), config);
                         }
                     }
 
-                    match layout {
-                        Layout::Vertical => write_vertical(language_backend, out, config, args),
-                        Layout::Horizontal => write_horizontal(language_backend, out, config, args),
-                        Layout::Auto => {
-                            if !out.try_write(
-                                |out| write_horizontal(language_backend, out, config, args),
-                                config.line_length,
-                            ) {
-                                write_vertical(language_backend, out, config, args)
+                    fn write_conditional<F: Write, LB: LanguageBackend>(
+                        language_backend: &mut LB,
+                        out: &mut SourceWriter<F>,
+                        config: &Config,
+                        args: &[CFuncArg],
+                    ) {
+                        let align_length = out.line_length_for_align();
+                        out.push_set_spaces(align_length);
+                        out.new_line();
+
+                        let mut has_unconditional_arg = false;
+                        let mut previous_conditions = Vec::new();
+
+                        // Keep the declaration valid when every cfg argument is disabled.
+                        if args.iter().all(|arg| arg.condition.is_some()) {
+                            let no_args_condition = Some(Condition::Not(Box::new(Condition::Any(
+                                args.iter()
+                                    .filter_map(|arg| arg.condition.clone())
+                                    .collect(),
+                            ))));
+                            no_args_condition.write_before(config, out);
+                            out.write("void");
+                            no_args_condition.write_after(config, out);
+                            out.new_line();
+                        }
+
+                        for arg in args {
+                            if arg.condition.is_some() {
+                                arg.condition.write_before(config, out);
+                            }
+
+                            if has_unconditional_arg {
+                                out.write(", ");
+                            } else if !previous_conditions.is_empty() {
+                                // Emit a comma only when an earlier cfg argument is present.
+                                let comma_condition =
+                                    Some(Condition::Any(previous_conditions.clone()));
+                                comma_condition.write_before(config, out);
+                                out.write(",");
+                                comma_condition.write_after(config, out);
+                                out.new_line();
+                            }
+
+                            arg.decl
+                                .write(language_backend, out, arg.ident.as_deref(), config);
+
+                            if let Some(condition) = &arg.condition {
+                                arg.condition.write_after(config, out);
+                                previous_conditions.push(condition.clone());
+                            } else {
+                                has_unconditional_arg = true;
+                            }
+                            out.new_line();
+                        }
+
+                        out.pop_tab();
+                    }
+
+                    if args.iter().any(|arg| arg.condition.is_some()) {
+                        write_conditional(language_backend, out, config, args);
+                    } else {
+                        match layout {
+                            Layout::Vertical => write_vertical(language_backend, out, config, args),
+                            Layout::Horizontal => {
+                                write_horizontal(language_backend, out, config, args)
+                            }
+                            Layout::Auto => {
+                                if !out.try_write(
+                                    |out| write_horizontal(language_backend, out, config, args),
+                                    config.line_length,
+                                ) {
+                                    write_vertical(language_backend, out, config, args)
+                                }
                             }
                         }
                     }

--- a/src/bindgen/ir/function.rs
+++ b/src/bindgen/ir/function.rs
@@ -21,6 +21,7 @@ pub struct FunctionArgument {
     pub name: Option<String>,
     pub ty: Type,
     pub array_length: Option<String>,
+    pub cfg: Option<Cfg>,
 }
 
 #[derive(Debug, Clone)]
@@ -53,6 +54,7 @@ impl Function {
                 name: None,
                 ty: Type::Primitive(super::PrimitiveType::VaList),
                 array_length: None,
+                cfg: None,
             })
         }
 
@@ -171,6 +173,7 @@ impl Function {
                         name,
                         ty: arg.ty,
                         array_length: None,
+                        cfg: arg.cfg,
                     }
                 })
                 .collect()
@@ -247,7 +250,10 @@ impl SynFnArgHelpers for syn::FnArg {
     fn as_argument(&self) -> Result<Option<FunctionArgument>, String> {
         match *self {
             syn::FnArg::Typed(syn::PatType {
-                ref pat, ref ty, ..
+                ref attrs,
+                ref pat,
+                ref ty,
+                ..
             }) => {
                 let ty = match Type::load(ty)? {
                     Some(x) => x,
@@ -275,12 +281,14 @@ impl SynFnArgHelpers for syn::FnArg {
                     name,
                     ty,
                     array_length: None,
+                    cfg: Cfg::load(attrs),
                 }))
             }
             syn::FnArg::Receiver(ref receiver) => Ok(Some(FunctionArgument {
                 name: Some("self".to_string()),
                 ty: gen_self_type(receiver)?,
                 array_length: None,
+                cfg: Cfg::load(&receiver.attrs),
             })),
         }
     }

--- a/tests/expectations-symbols/cfg_function_args.c.sym
+++ b/tests/expectations-symbols/cfg_function_args.c.sym
@@ -1,0 +1,5 @@
+{
+cfg_function_args;
+cfg_first_argument;
+cfg_all_arguments;
+};

--- a/tests/expectations/cfg_function_args.c
+++ b/tests/expectations/cfg_function_args.c
@@ -1,0 +1,40 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+void cfg_function_args(
+                       uint32_t first
+#if defined(DEFINED)
+                       , uint32_t enabled
+#endif
+#if defined(UNDEFINED)
+                       , uint32_t disabled
+#endif
+                       , uint32_t last
+);
+
+void cfg_first_argument(
+#if defined(DEFINED)
+                        uint32_t enabled
+#endif
+#if (defined(DEFINED))
+                        ,
+#endif
+                        uint32_t last
+);
+
+void cfg_all_arguments(
+#if !(defined(DEFINED) || defined(UNDEFINED))
+                       void
+#endif
+#if defined(DEFINED)
+                       uint32_t enabled
+#endif
+#if defined(UNDEFINED)
+#if (defined(DEFINED))
+                       ,
+#endif
+                       uint32_t disabled
+#endif
+);

--- a/tests/expectations/cfg_function_args.compat.c
+++ b/tests/expectations/cfg_function_args.compat.c
@@ -1,0 +1,48 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void cfg_function_args(
+                       uint32_t first
+#if defined(DEFINED)
+                       , uint32_t enabled
+#endif
+#if defined(UNDEFINED)
+                       , uint32_t disabled
+#endif
+                       , uint32_t last
+);
+
+void cfg_first_argument(
+#if defined(DEFINED)
+                        uint32_t enabled
+#endif
+#if (defined(DEFINED))
+                        ,
+#endif
+                        uint32_t last
+);
+
+void cfg_all_arguments(
+#if !(defined(DEFINED) || defined(UNDEFINED))
+                       void
+#endif
+#if defined(DEFINED)
+                       uint32_t enabled
+#endif
+#if defined(UNDEFINED)
+#if (defined(DEFINED))
+                       ,
+#endif
+                       uint32_t disabled
+#endif
+);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus

--- a/tests/expectations/cfg_function_args.cpp
+++ b/tests/expectations/cfg_function_args.cpp
@@ -1,0 +1,45 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <ostream>
+#include <new>
+
+extern "C" {
+
+void cfg_function_args(
+                       uint32_t first
+#if defined(DEFINED)
+                       , uint32_t enabled
+#endif
+#if defined(UNDEFINED)
+                       , uint32_t disabled
+#endif
+                       , uint32_t last
+);
+
+void cfg_first_argument(
+#if defined(DEFINED)
+                        uint32_t enabled
+#endif
+#if (defined(DEFINED))
+                        ,
+#endif
+                        uint32_t last
+);
+
+void cfg_all_arguments(
+#if !(defined(DEFINED) || defined(UNDEFINED))
+                       void
+#endif
+#if defined(DEFINED)
+                       uint32_t enabled
+#endif
+#if defined(UNDEFINED)
+#if (defined(DEFINED))
+                       ,
+#endif
+                       uint32_t disabled
+#endif
+);
+
+}  // extern "C"

--- a/tests/expectations/cfg_function_args.pyx
+++ b/tests/expectations/cfg_function_args.pyx
@@ -1,0 +1,13 @@
+from libc.stdint cimport int8_t, int16_t, int32_t, int64_t, intptr_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
+cdef extern from *:
+  ctypedef bint bool
+  ctypedef struct va_list
+
+cdef extern from *:
+
+  void cfg_function_args(uint32_t first, uint32_t enabled, uint32_t disabled, uint32_t last);
+
+  void cfg_first_argument(uint32_t enabled, uint32_t last);
+
+  void cfg_all_arguments(uint32_t enabled, uint32_t disabled);

--- a/tests/rust/cfg_function_args.rs
+++ b/tests/rust/cfg_function_args.rs
@@ -1,0 +1,25 @@
+#[allow(unexpected_cfgs)]
+#[no_mangle]
+pub extern "C" fn cfg_function_args(
+    first: u32,
+    #[cfg(feature = "enabled")] enabled: u32,
+    #[cfg(feature = "disabled")] disabled: u32,
+    last: u32,
+) {
+}
+
+#[allow(unexpected_cfgs)]
+#[no_mangle]
+pub extern "C" fn cfg_first_argument(
+    #[cfg(feature = "enabled")] enabled: u32,
+    last: u32,
+) {
+}
+
+#[allow(unexpected_cfgs)]
+#[no_mangle]
+pub extern "C" fn cfg_all_arguments(
+    #[cfg(feature = "enabled")] enabled: u32,
+    #[cfg(feature = "disabled")] disabled: u32,
+) {
+}

--- a/tests/rust/cfg_function_args.toml
+++ b/tests/rust/cfg_function_args.toml
@@ -1,0 +1,3 @@
+[defines]
+"feature = enabled" = "DEFINED"
+"feature = disabled" = "UNDEFINED"


### PR DESCRIPTION
## Summary

- preserve `#[cfg]` attributes when loading function arguments into the IR
- emit cfg-aware C/C++ parameter lists with valid comma placement
- emit `void` when every conditional argument is disabled
- omit `swift_name` attributes when conditional parameters would make their fixed arity invalid
- add regression fixtures for conditional arguments in leading, middle, trailing, and all-conditional positions

Fixes #1037.

## Testing

- `CBINDGEN_TEST_VERIFY=1 cargo test --test tests` with nightly on `PATH`: 159/159 passed
- generated C and C++ compiled with Clang using neither define, each define independently, and both defines
- `cargo test --lib --bins`: 4/4 passed
- `cargo check --all-targets`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo clippy --all-targets -- -D warnings` reaches a pre-existing `clippy::too_many_arguments` finding in `tests/tests.rs:31`; the changed production code is not implicated

## AI disclosure

I used OpenAI Codex to assist with issue discovery, implementation, and test execution. I reviewed and understand the changes and verified them locally.